### PR TITLE
[fix] #19 로그인과 회원가입 방식 변경

### DIFF
--- a/src/main/java/com/yoyomo/domain/user/application/dto/req/RegisterRequest.java
+++ b/src/main/java/com/yoyomo/domain/user/application/dto/req/RegisterRequest.java
@@ -6,7 +6,7 @@ import lombok.extern.jackson.Jacksonized;
 
 @Getter
 @Builder
-@Jacksonized
 public class RegisterRequest {
-    private String email;
+    private String code;
+    private String name;
 }

--- a/src/main/java/com/yoyomo/domain/user/presentation/UserController.java
+++ b/src/main/java/com/yoyomo/domain/user/presentation/UserController.java
@@ -23,7 +23,7 @@ public class UserController {
     @PostMapping(value = "/register")
     @Operation(summary = "회원가입")
     public ResponseDto<UserResponse>  register(@RequestBody RegisterRequest request) throws Exception {
-        UserResponse response = userManageUseCase.register(request.getEmail());
+        UserResponse response = userManageUseCase.register(request);
         return ResponseDto.of(OK.value(), SUCCESS_REGISTER.getMessage(),response);
     }
 


### PR DESCRIPTION
## 🚀 PR 요약

로그인과 회원가입 방식 변경합니다.

## ✨ PR 상세 내용

기존에는 회원가입시에 추가 정보가 필요 없어, 로그인 시 계정이 없을때 바로 회원가입을 진행. 
이를 404응답으로 바꾸고 유저 정보와 함께 회원가입으로 변경

## 🚨 주의 사항


## ✅ 체크 리스트

- [.] 리뷰어 설정했나요?
- [.] Label 설정했나요?
- [.] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [.] 변경 사항에 대한 테스트 진행했나요?
