### PR TITLE
fix: 모집 수정시 isRecruitmentActive 수정 추가

### DIFF
--- a/src/main/java/com/yoyomo/domain/recruitment/application/dto/req/RecruitmentModifyRequest.java
+++ b/src/main/java/com/yoyomo/domain/recruitment/application/dto/req/RecruitmentModifyRequest.java
@@ -1,0 +1,27 @@
+package com.yoyomo.domain.recruitment.application.dto.req;
+
+import com.yoyomo.domain.recruitment.domain.entity.Process;
+
+import java.util.List;
+
+public record RecruitmentModifyRequest(
+        String clubId,
+        String formId,
+        String title,
+        Integer generation,
+        String position,
+        Boolean isRecruitmentActive,
+        List<Process> processes
+) {
+    public RecruitmentModifyRequest withClubId(String newClubId) {
+        return new RecruitmentModifyRequest(
+                newClubId,
+                this.formId,
+                this.title,
+                this.generation,
+                this.position,
+                this.isRecruitmentActive,
+                this.processes
+        );
+    }
+}

--- a/src/main/java/com/yoyomo/domain/recruitment/application/usecase/RecruitmentManageUseCase.java
+++ b/src/main/java/com/yoyomo/domain/recruitment/application/usecase/RecruitmentManageUseCase.java
@@ -1,6 +1,7 @@
 package com.yoyomo.domain.recruitment.application.usecase;
 
 import com.yoyomo.domain.form.application.dto.req.FormUpdateRequest;
+import com.yoyomo.domain.recruitment.application.dto.req.RecruitmentModifyRequest;
 import com.yoyomo.domain.recruitment.application.dto.req.RecruitmentRequest;
 import com.yoyomo.domain.recruitment.application.dto.res.RecruitmentDetailsResponse;
 import com.yoyomo.domain.recruitment.application.dto.res.RecruitmentResponse;
@@ -14,7 +15,7 @@ public interface RecruitmentManageUseCase {
 
     List<RecruitmentResponse> readAll(String clubId);
 
-    void update(String recruitmentId, RecruitmentRequest request);
+    void update(String recruitmentId, RecruitmentModifyRequest request);
 
     void update(String recruitmentId, FormUpdateRequest request);
 

--- a/src/main/java/com/yoyomo/domain/recruitment/application/usecase/RecruitmentManageUseCaseImpl.java
+++ b/src/main/java/com/yoyomo/domain/recruitment/application/usecase/RecruitmentManageUseCaseImpl.java
@@ -7,6 +7,7 @@ import com.yoyomo.domain.form.domain.entity.Form;
 import com.yoyomo.domain.form.domain.service.FormGetService;
 import com.yoyomo.domain.item.application.usecase.ItemManageUseCase;
 import com.yoyomo.domain.item.domain.entity.Item;
+import com.yoyomo.domain.recruitment.application.dto.req.RecruitmentModifyRequest;
 import com.yoyomo.domain.recruitment.application.dto.req.RecruitmentRequest;
 import com.yoyomo.domain.recruitment.application.dto.res.RecruitmentDetailsResponse;
 import com.yoyomo.domain.recruitment.application.dto.res.RecruitmentResponse;
@@ -54,7 +55,7 @@ public class RecruitmentManageUseCaseImpl implements RecruitmentManageUseCase {
     }
 
     @Override
-    public void update(String recruitmentId, RecruitmentRequest request) {
+    public void update(String recruitmentId, RecruitmentModifyRequest request) {
         if (request.formId() != null) {
             Form form = formGetService.find(request.formId());
             recruitmentUpdateService.from(recruitmentId, form);

--- a/src/main/java/com/yoyomo/domain/recruitment/domain/service/RecruitmentUpdateService.java
+++ b/src/main/java/com/yoyomo/domain/recruitment/domain/service/RecruitmentUpdateService.java
@@ -2,6 +2,7 @@ package com.yoyomo.domain.recruitment.domain.service;
 
 import com.mongodb.client.result.UpdateResult;
 import com.yoyomo.domain.form.domain.entity.Form;
+import com.yoyomo.domain.recruitment.application.dto.req.RecruitmentModifyRequest;
 import com.yoyomo.domain.recruitment.application.dto.req.RecruitmentRequest;
 import com.yoyomo.domain.recruitment.domain.entity.Recruitment;
 import com.yoyomo.domain.recruitment.exception.RecruitmentNotFoundException;
@@ -24,7 +25,7 @@ public class RecruitmentUpdateService {
     private static final String DELETED_AT = "deletedAt";
     private final MongoTemplate mongoTemplate;
 
-    public void from(String id, RecruitmentRequest request) {
+    public void from(String id, RecruitmentModifyRequest request) {
         Query query = query(
                 where(ID).is(id).and(DELETED_AT).isNull()
         );

--- a/src/main/java/com/yoyomo/domain/recruitment/presentation/RecruitmentController.java
+++ b/src/main/java/com/yoyomo/domain/recruitment/presentation/RecruitmentController.java
@@ -2,6 +2,7 @@ package com.yoyomo.domain.recruitment.presentation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.yoyomo.domain.form.application.dto.req.FormUpdateRequest;
+import com.yoyomo.domain.recruitment.application.dto.req.RecruitmentModifyRequest;
 import com.yoyomo.domain.recruitment.application.dto.req.RecruitmentRequest;
 import com.yoyomo.domain.recruitment.application.dto.res.RecruitmentDetailsResponse;
 import com.yoyomo.domain.recruitment.application.dto.res.RecruitmentResponse;
@@ -61,7 +62,7 @@ public class RecruitmentController {
 
     @PatchMapping("/{recruitmentId}")
     @Operation(summary = "모집 수정", description = "지원폼을 제외한 모집 정보를 수정합니다.")
-    public ResponseDto update(@PathVariable String recruitmentId, @RequestBody RecruitmentRequest request) {
+    public ResponseDto update(@PathVariable String recruitmentId, @RequestBody RecruitmentModifyRequest request) {
         recruitmentManageUseCase.update(recruitmentId, request);
         return ResponseDto.of(OK.value(), SUCCESS_UPDATE.getMessage());
     }


### PR DESCRIPTION
## 🚀 PR 요약
모집 수정시 isRecruitmentActive 수정 추가 로직

## ✨ PR 상세 내용
<img width="380" alt="Screenshot 2024-06-23 at 11 09 13 PM" src="https://github.com/Tough-Guy-Money-Party/Crayon-BE/assets/24919880/37eda10b-adec-4c16-a144-b07fce035bfd">

<img width="529" alt="Screenshot 2024-06-23 at 11 55 06 PM" src="https://github.com/Tough-Guy-Money-Party/Crayon-BE/assets/24919880/2f3c62fb-20c0-415e-a6c6-0cf8e88bf57b">

## 🚨 주의 사항
isRecruitmentActive 수정을 이런식으로 하는게 좋은지, 아니면 figma보면 슬라이드 통해서 하는거 같은데 API를 사용하면 좋을지 피드백 부탁드립니다. 
@Collection50 


## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
