### PR TITLE
CRA-50 평가 중복 로직 수정

### DIFF
--- a/src/main/java/com/yoyomo/domain/application/domain/repository/EvaluationRepository.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/repository/EvaluationRepository.java
@@ -14,5 +14,5 @@ public interface EvaluationRepository extends JpaRepository<Evaluation, Long> {
 
     List<Evaluation> findAllByProcessIdAndApplication(long processId, Application application);
 
-    boolean existsByManager(User manager);
+    boolean existsByManagerAndApplication(User manager, Application application);
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/service/EvaluationSaveService.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/service/EvaluationSaveService.java
@@ -14,7 +14,7 @@ public class EvaluationSaveService {
     private final EvaluationRepository evaluationRepository;
 
     public Evaluation save(User manager, Evaluation evaluation) {
-        if (evaluationRepository.existsByManager(manager)) {
+        if (evaluationRepository.existsByManagerAndApplication(manager, evaluation.getApplication())) {
             throw new EvaluationAlreadyExistException();
         }
         return evaluationRepository.save(evaluation);


### PR DESCRIPTION
## 🚀 PR 요약
평가 생성 시 관리자와 지원서로 평가 존재 여부 판단하도록 수정했습니다.

## ✨ PR 상세 내용
기존에 이미 평가가 존재하는지 판단하는 로직을 관리자 여부로만 판단하였습니다.
그래서 다른 지원서에 동일한 관리자의 평가 생성이 불가능한 버그가 있었습니다.

평가 여부를 관리자와 지원서를 함께 조회하여 검증함으로써 지원서 당 관리자는 한 번 평가 가능하도록 변경하였습니다.

## 🚨 주의 사항
주의할 부분이 무엇인가요? - 지우고 작성

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
