### PR TITLE
CRA-48 메일 업로드 시 트랜잭션 추가

### DIFF
--- a/src/main/java/com/yoyomo/domain/mail/domain/service/MailSaveService.java
+++ b/src/main/java/com/yoyomo/domain/mail/domain/service/MailSaveService.java
@@ -1,34 +1,33 @@
 package com.yoyomo.domain.mail.domain.service;
 
 import com.yoyomo.domain.mail.domain.entity.Mail;
+import com.yoyomo.global.common.util.BatchDivider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
-import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteItemEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.model.WriteBatch;
+import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class MailSaveService {
 
-    private static final int BATCH_SIZE = 25;
+    private static final int BATCH_SIZE = 50;
 
+    private final BatchDivider batchDivider;
     private final DynamoDbEnhancedAsyncClient dynamoDbEnhancedAsyncClient;
     private final DynamoDbAsyncTable<Mail> mailTable;
 
     public CompletableFuture<Void> upload(List<Mail> mails) {
-        List<List<Mail>> batches = divide(mails);
+        List<List<Mail>> batches = batchDivider.divide(mails, BATCH_SIZE);
         log.info("[MailSaveService] | Divided mails into {} batches.", batches.size());
 
         List<CompletableFuture<Void>> futures = batches.stream()
@@ -44,29 +43,20 @@ public class MailSaveService {
     }
 
     private CompletableFuture<Void> batchWrite(List<Mail> batch) {
-        WriteBatch.Builder<Mail> writeBatchBuilder = WriteBatch.builder(Mail.class)
-                .mappedTableResource(mailTable);
+        TransactWriteItemsEnhancedRequest.Builder requestBuilder = TransactWriteItemsEnhancedRequest.builder();
 
         for (Mail mail : batch) {
-            writeBatchBuilder.addPutItem(mail);
+            requestBuilder.addPutItem(mailTable, mail);
         }
 
-        BatchWriteItemEnhancedRequest batchWriteItemEnhancedRequest = BatchWriteItemEnhancedRequest.builder()
-                .addWriteBatch(writeBatchBuilder.build())
-                .build();
+        TransactWriteItemsEnhancedRequest request = requestBuilder.build();
 
-        return dynamoDbEnhancedAsyncClient.batchWriteItem(batchWriteItemEnhancedRequest)
-                .thenAccept(result -> log.info("[MailSaveService] | {} 개의 메일 배치 업로드 성공", batch.size()))
+        return dynamoDbEnhancedAsyncClient.transactWriteItems(request)
+                .thenAccept(result -> log.info("[MailSaveService] | {} 개의 메일 트랜잭션 업로드 성공", batch.size()))
                 .exceptionally(ex -> {
                     log.error("[MailSaveService] | 배치 업로드 중 예외 발생: {}", ex.getMessage(), ex);
                     throw new CompletionException(ex);
                 });
-    }
-
-    private <T> List<List<T>> divide(List<T> list) {
-        return IntStream.range(0, (list.size() + BATCH_SIZE - 1) / BATCH_SIZE)
-                .mapToObj(i -> list.subList(i * BATCH_SIZE, Math.min((i + 1) * BATCH_SIZE, list.size())))
-                .collect(Collectors.toList());
     }
 
     /*


### PR DESCRIPTION
## 🚀 PR 요약
- 메일 업로드 시 기존에 없던 트랜잭션을 추가했습니다
- 업로드 API를 수정해 트랜잭션이 적용되도록 했습니다

## ✨ PR 상세 내용
- 기존 `batchWriteItem`을 사용하던 것에서 `TransactWriteItemsEnhancedRequest`로 요청하는 API 방식을 수정했습니다
- 해당 API는 최대 요청이 100개라서 우선 50개로 사이즈를 상향했습니다. 테스트 후 적절한 크기로 재설정하겠습니다

메일 업로드 테스트
<img width="438" alt="image" src="https://github.com/user-attachments/assets/15bf1dde-5cab-44e8-bc74-f8e8365990b4" />

<img width="619" alt="image" src="https://github.com/user-attachments/assets/0640d152-9cc4-49c8-bc9a-2f3a33e67a7e" />


## 🚨 주의 사항
- 아직 실패 상황 테스트는 진행해보지 못했습니다. 차후 작업해서 업로드/수정/취소 시 중간에 오류를 집어넣어서 트랜잭션/로깅/예외 처리가 적절하게 이루어지는지 테스트하겠습니다
- 기존 `MailUpdateService`에서 `TransactWriteItemsEnhancedRequest`를 사용하지 않고, 조금 더 저수준의 API를 사용하고 있어서 통일하는 것이 좋아보여 다음 작업에서 수정하겠습니다


## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
