### PR TITLE
CRA-90 서브도메인을 생성하지 않은 경우 홍보페이지 유무를 조회할 수 없는 현상 수정

### DIFF
--- a/src/main/java/com/yoyomo/domain/club/domain/entity/Club.java
+++ b/src/main/java/com/yoyomo/domain/club/domain/entity/Club.java
@@ -79,6 +79,6 @@ public class Club extends BaseEntity {
     }
 
     public boolean checkExistsSubDomain() {
-        return !subDomain.isEmpty();
+        return !(subDomain == null);
     }
 }


### PR DESCRIPTION
## 🚀 PR 요약

서브도메인을 생성하지 않은 경우 홍보페이지 유무를 조회할 수 없는 현상을 수정했습니다.

## ✨ PR 상세 내용

`subDomain.isEmpty()` 로 검증을 하고 있었는데 이때 null인 경우 에러가 발생합니다
따라서 `subDomain == null` 로 검증하도록 코드를 변경했습니다.

## 🚨 주의 사항
주의할 부분이 무엇인가요? - 지우고 작성

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?

close #280 
