### PR TITLE
CRA-95 폼 생성시 description이 없어도 생성 가능하게 변경

### DIFF
--- a/src/main/java/com/yoyomo/domain/item/application/dto/req/ItemRequest.java
+++ b/src/main/java/com/yoyomo/domain/item/application/dto/req/ItemRequest.java
@@ -8,7 +8,7 @@ import java.util.List;
 public record ItemRequest(
         @NotEmpty String title,
         @NotNull Type type,
-        @NotEmpty String description,
+        String description,
         @NotNull int order,
         @NotNull boolean required,
 


### PR DESCRIPTION
## 🚀 PR 요약

폼 생성시 description없이 생성 가능하게 변경했습니다.

## ✨ PR 상세 내용

item request의 description의 `NotEmpty` 를 삭제했습니다.

## 🚨 주의 사항

없습니다.

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
