### PR TITLE
Fix/cra 109

### DIFF
--- a/src/main/java/com/yoyomo/domain/application/application/dto/response/ApplicationDetailResponse.java
+++ b/src/main/java/com/yoyomo/domain/application/application/dto/response/ApplicationDetailResponse.java
@@ -3,6 +3,7 @@ package com.yoyomo.domain.application.application.dto.response;
 import com.yoyomo.domain.application.domain.entity.Answer;
 import com.yoyomo.domain.application.domain.entity.Application;
 import com.yoyomo.domain.application.domain.entity.Interview;
+import com.yoyomo.domain.application.domain.entity.ProcessResult;
 import com.yoyomo.domain.application.domain.entity.enums.Status;
 import com.yoyomo.domain.recruitment.domain.entity.enums.Type;
 
@@ -21,11 +22,11 @@ public record ApplicationDetailResponse(
         AnswerResponseDTO.Response answer
 ) {
 
-    public static ApplicationDetailResponse toResponse(Application application, Answer answer, List<Type> types) {
+    public static ApplicationDetailResponse toResponse(Application application, Answer answer, List<Type> types, ProcessResult processResult) {
         return new ApplicationDetailResponse(
                 application.getId().toString(),
                 ApplicantResponse.toResponse(application),
-                application.getStatus(),
+                processResult.getStatus(),
                 application.getInterview(),
                 application.isBeforeInterview(types),
                 application.getProcess().getStage(),

--- a/src/main/java/com/yoyomo/domain/application/application/dto/response/ApplicationListResponse.java
+++ b/src/main/java/com/yoyomo/domain/application/application/dto/response/ApplicationListResponse.java
@@ -2,7 +2,11 @@ package com.yoyomo.domain.application.application.dto.response;
 
 import com.yoyomo.domain.application.domain.entity.Application;
 import com.yoyomo.domain.application.domain.entity.enums.Status;
+import org.springframework.data.domain.Page;
+
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public record ApplicationListResponse(
@@ -13,13 +17,23 @@ public record ApplicationListResponse(
         Status status,
         LocalDateTime createdAt
 ) {
-    public static ApplicationListResponse toResponse(Application application) {
+    public static List<ApplicationListResponse> toResponse(List<Application> applications, Map<UUID, Status> status) {
+        return applications.stream()
+                .map(application -> toResponse(application, status.getOrDefault(application.getId(), Status.BEFORE_EVALUATION)))
+                .toList();
+    }
+
+    public static Page<ApplicationListResponse> toResponse(Page<Application> applications, Map<UUID, Status> status) {
+        return applications.map(application -> toResponse(application, status.getOrDefault(application.getId(), Status.BEFORE_EVALUATION)));
+    }
+
+    private static ApplicationListResponse toResponse(Application application, Status status) {
         return new ApplicationListResponse(
                 application.getId(),
                 application.getUserName(),
                 application.getEmail(),
                 application.getTel(),
-                application.getStatus(),
+                status,
                 application.getCreatedAt()
         );
     }

--- a/src/main/java/com/yoyomo/domain/application/application/dto/response/EvaluationResponse.java
+++ b/src/main/java/com/yoyomo/domain/application/application/dto/response/EvaluationResponse.java
@@ -1,27 +1,46 @@
 package com.yoyomo.domain.application.application.dto.response;
 
-import com.yoyomo.domain.application.domain.entity.Application;
 import com.yoyomo.domain.application.domain.entity.Evaluation;
+import com.yoyomo.domain.application.domain.entity.ProcessResult;
 import com.yoyomo.domain.application.domain.entity.enums.Rating;
 import com.yoyomo.domain.application.domain.entity.enums.Status;
 import lombok.Builder;
 
+import java.util.List;
 import java.util.Map;
 
 @Builder
 public record EvaluationResponse(
-        Status status,
+        List<StatusResponse> status,
         Long myEvaluationId,
         Rating myRating,
         RatingResponse ratingResponse
 ) {
-    public static EvaluationResponse toResponse(Application application, Evaluation myEvaluation, Map<Rating, Long> ratingCount) {
+
+    public static EvaluationResponse toResponse(
+            List<ProcessResult> processResults,
+            Evaluation myEvaluation,
+            Map<Rating, Long> ratingCount
+    ) {
         RatingResponse ratingResponses = RatingResponse.toResponse(ratingCount);
+        List<StatusResponse> statusResponses = processResults.stream()
+                .map(StatusResponse::toResponse)
+                .toList();
         return EvaluationResponse.builder()
-                .status(application.getStatus())
+                .status(statusResponses)
                 .myEvaluationId(myEvaluation.getId())
                 .myRating(myEvaluation.getRating())
                 .ratingResponse(ratingResponses)
                 .build();
+    }
+
+    private record StatusResponse(
+            long processId,
+            Status status
+    ) {
+
+        private static StatusResponse toResponse(ProcessResult processResult) {
+            return new StatusResponse(processResult.getProcessId(), processResult.getStatus());
+        }
     }
 }

--- a/src/main/java/com/yoyomo/domain/application/application/dto/response/EvaluationResponses.java
+++ b/src/main/java/com/yoyomo/domain/application/application/dto/response/EvaluationResponses.java
@@ -1,8 +1,8 @@
 package com.yoyomo.domain.application.application.dto.response;
 
-import com.yoyomo.domain.application.domain.entity.Application;
 import com.yoyomo.domain.application.domain.entity.Evaluation;
 import com.yoyomo.domain.application.domain.entity.EvaluationMemo;
+import com.yoyomo.domain.application.domain.entity.ProcessResult;
 import com.yoyomo.domain.application.domain.entity.enums.Rating;
 
 import java.util.List;
@@ -13,10 +13,15 @@ public record EvaluationResponses(
         EvaluationResponse evaluationResponse,
         List<EvaluationMemoResponse> memoResponses
 ) {
-    public static EvaluationResponses toResponse(Application application, Evaluation myEvaluation, List<Evaluation> evaluations, List<EvaluationMemo> memos) {
+    public static EvaluationResponses toResponse(
+            List<ProcessResult> processResult,
+            Evaluation myEvaluation,
+            List<Evaluation> evaluations,
+            List<EvaluationMemo> memos
+    ) {
         Map<Rating, Long> ratingCount = evaluations.stream()
                 .collect(Collectors.groupingBy(Evaluation::getRating, Collectors.counting()));
-        EvaluationResponse evaluationResponse = EvaluationResponse.toResponse(application, myEvaluation, ratingCount);
+        EvaluationResponse evaluationResponse = EvaluationResponse.toResponse(processResult, myEvaluation, ratingCount);
 
         List<EvaluationMemoResponse> memoResponses = memos.stream()
                 .map(EvaluationMemoResponse::toResponse)

--- a/src/main/java/com/yoyomo/domain/application/application/usecase/EvaluationManageUseCase.java
+++ b/src/main/java/com/yoyomo/domain/application/application/usecase/EvaluationManageUseCase.java
@@ -7,6 +7,7 @@ import com.yoyomo.domain.application.application.dto.response.EvaluationResponse
 import com.yoyomo.domain.application.domain.entity.Application;
 import com.yoyomo.domain.application.domain.entity.Evaluation;
 import com.yoyomo.domain.application.domain.entity.EvaluationMemo;
+import com.yoyomo.domain.application.domain.entity.ProcessResult;
 import com.yoyomo.domain.application.domain.service.ApplicationGetService;
 import com.yoyomo.domain.application.domain.service.ApplicationUpdateService;
 import com.yoyomo.domain.application.domain.service.EvaluationGetService;
@@ -14,6 +15,7 @@ import com.yoyomo.domain.application.domain.service.EvaluationMemoGetService;
 import com.yoyomo.domain.application.domain.service.EvaluationMemoSaveService;
 import com.yoyomo.domain.application.domain.service.EvaluationSaveService;
 import com.yoyomo.domain.application.domain.service.EvaluationUpdateService;
+import com.yoyomo.domain.application.domain.service.ProcessResultGetService;
 import com.yoyomo.domain.club.domain.service.ClubManagerAuthService;
 import com.yoyomo.domain.user.domain.entity.User;
 import com.yoyomo.domain.user.domain.service.UserGetService;
@@ -36,17 +38,19 @@ public class EvaluationManageUseCase {
     private final EvaluationUpdateService evaluationUpdateService;
     private final EvaluationMemoSaveService evaluationMemoSaveService;
     private final EvaluationMemoGetService evaluationMemoGetService;
+    private final ProcessResultGetService processResultGetService;
 
     @Transactional(readOnly = true)
     public EvaluationResponses findEvaluations(String applicationId, long userId) {
         Application application = applicationGetService.find(applicationId);
         User manager = userGetService.find(userId);
         clubManagerAuthService.checkAuthorization(application.getRecruitmentId(), manager);
+        List<ProcessResult> processResult = processResultGetService.find(application);
 
         List<Evaluation> evaluations = evaluationGetService.findAllInStage(application);
         Evaluation myEvaluation = evaluationGetService.findMyEvaluation(evaluations, manager);
         List<EvaluationMemo> memos = evaluationMemoGetService.findAllInStage(application);
-        return EvaluationResponses.toResponse(application, myEvaluation, evaluations, memos);
+        return EvaluationResponses.toResponse(processResult, myEvaluation, evaluations, memos);
     }
 
     @Transactional

--- a/src/main/java/com/yoyomo/domain/application/domain/entity/ProcessResult.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/entity/ProcessResult.java
@@ -13,6 +13,7 @@ import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,6 +22,7 @@ import java.util.UUID;
 @Getter
 @Builder
 @Entity
+@EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(uniqueConstraints = {

--- a/src/main/java/com/yoyomo/domain/application/domain/entity/ProcessResult.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/entity/ProcessResult.java
@@ -1,0 +1,57 @@
+package com.yoyomo.domain.application.domain.entity;
+
+import com.yoyomo.domain.application.domain.entity.enums.Status;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(uniqueConstraints = {
+        @UniqueConstraint(
+                columnNames = {"application_id", "process_id"}
+        )})
+public class ProcessResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "process_result_id")
+    private Long id;
+
+    @Column(name = "application_id", nullable = false)
+    private UUID applicationId;
+
+    @Column(name = "process_id", nullable = false)
+    private long processId;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    private Status status = Status.BEFORE_EVALUATION;
+
+    public static ProcessResult getBeforeEvaluationResult(UUID applicationId, long processId) {
+        return ProcessResult.builder()
+                .applicationId(applicationId)
+                .processId(processId)
+                .build();
+    }
+
+    public void updateStatus(Status status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/domain/entity/enums/Status.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/entity/enums/Status.java
@@ -1,6 +1,11 @@
 package com.yoyomo.domain.application.domain.entity.enums;
 
 public enum Status {
+
+    /**
+     * BEFORE_EVALUATION, PASS, FAIL, PENDING 만 남길것.
+     * Process와 조합 => 각 단계별 평가상태.
+     */
     BEFORE_EVALUATION,
     DOCUMENT_PASS,
     DOCUMENT_FAIL,

--- a/src/main/java/com/yoyomo/domain/application/domain/repository/ApplicationRepository.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/repository/ApplicationRepository.java
@@ -26,8 +26,6 @@ public interface ApplicationRepository extends JpaRepository<Application, UUID> 
     Page<Application> findAllByUserNameContainingAndProcessAndDeletedAtIsNull(String userName, Process process,
                                                                               Pageable pageable);
 
-    List<Application> findAllByProcessAndStatusAndDeletedAtIsNull(Process process, Status status);
-
     Optional<Application> findByIdAndDeletedAtIsNull(UUID id);
 
     @Query("""
@@ -64,7 +62,8 @@ public interface ApplicationRepository extends JpaRepository<Application, UUID> 
     List<ProcessApplicant> countByRecruitmentAndProcess(UUID recruitmentId, List<Process> processes);
 
     @Modifying
-    @Query("UPDATE Application a SET a.process = :process, a.status = :status WHERE a IN :applications")
-    void updateProcess(@Param("process") Process process, @Param("status") Status status,
-                       @Param("applications") List<Application> applications);
+    @Query("UPDATE Application a SET a.process = :process, a.status = :status WHERE a.id IN :applicationIds")
+    void updateProcess(@Param("applicationIds") List<UUID> applicationIds,
+                       @Param("process") Process process,
+                       @Param("status") Status status);
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/repository/ProcessResultRepository.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/repository/ProcessResultRepository.java
@@ -1,0 +1,31 @@
+package com.yoyomo.domain.application.domain.repository;
+
+import com.yoyomo.domain.application.domain.entity.ProcessResult;
+import com.yoyomo.domain.application.domain.entity.enums.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+
+public interface ProcessResultRepository extends JpaRepository<ProcessResult, Long> {
+
+    @Query("""
+            SELECT pr
+            FROM ProcessResult pr
+            WHERE pr.processId = :processId AND pr.applicationId IN :applicationIds
+            ORDER BY
+                CASE WHEN pr.status = 'PENDING' THEN 0 ELSE 1 END ASC,
+                pr.id DESC
+            """)
+    List<ProcessResult> findAllByProcessId(@Param("processId") long processId, @Param("applicationIds") List<UUID> applicationIds);
+
+    Optional<ProcessResult> findByApplicationIdAndProcessId(UUID applicationId, Long processId);
+
+    List<ProcessResult> findAllByProcessIdAndStatus(long processId, Status status);
+
+    List<ProcessResult> findAllByApplicationIdAndProcessIdIsLessThanEqual(UUID applicationId, long processId);
+}

--- a/src/main/java/com/yoyomo/domain/application/domain/service/ApplicationGetService.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/service/ApplicationGetService.java
@@ -1,12 +1,10 @@
 package com.yoyomo.domain.application.domain.service;
 
 import com.yoyomo.domain.application.domain.entity.Application;
-import com.yoyomo.domain.application.domain.entity.enums.Status;
 import com.yoyomo.domain.application.domain.repository.ApplicationRepository;
 import com.yoyomo.domain.application.domain.repository.dto.ProcessApplicant;
 import com.yoyomo.domain.application.exception.ApplicationNotFoundException;
 import com.yoyomo.domain.recruitment.domain.entity.Process;
-import com.yoyomo.domain.recruitment.domain.repository.ProcessRepository;
 import com.yoyomo.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -24,7 +22,6 @@ import java.util.stream.Collectors;
 public class ApplicationGetService {
 
     private final ApplicationRepository applicationRepository;
-    private final ProcessRepository processRepository;
 
     public List<Application> findAll(User user) {
         return applicationRepository.findAllByUserAndDeletedAtIsNull(user);
@@ -39,10 +36,6 @@ public class ApplicationGetService {
         return applicationRepository.findAllByProcessOrderByPending(process, pageable);
     }
 
-    public List<Application> findAll(Process process, Status status) {
-        return applicationRepository.findAllByProcessAndStatusAndDeletedAtIsNull(process, status);
-    }
-
     public List<Application> findAll(Process process) {
         return applicationRepository.findAllByProcessOrderByPending(process);
     }
@@ -55,12 +48,6 @@ public class ApplicationGetService {
     public Application find(UUID applicationId) {
         return applicationRepository.findByIdAndDeletedAtIsNull(applicationId)
                 .orElseThrow(ApplicationNotFoundException::new);
-    }
-
-    public List<UUID> getApplicationIds(Page<Application> applications) {
-        return applications.stream()
-                .map(Application::getId)
-                .toList();
     }
 
     public Page<Application> findByName(String name, Process process, Pageable pageable) {

--- a/src/main/java/com/yoyomo/domain/application/domain/service/ProcessResultGetService.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/service/ProcessResultGetService.java
@@ -1,0 +1,59 @@
+package com.yoyomo.domain.application.domain.service;
+
+import com.yoyomo.domain.application.domain.entity.Application;
+import com.yoyomo.domain.application.domain.entity.ProcessResult;
+import com.yoyomo.domain.application.domain.entity.enums.Status;
+import com.yoyomo.domain.application.domain.repository.ProcessResultRepository;
+import com.yoyomo.domain.recruitment.domain.entity.Process;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ProcessResultGetService {
+
+    private final ProcessResultRepository processResultRepository;
+
+    public Map<UUID, Status> findAll(Process process, List<Application> applications) {
+        List<UUID> applicationIds = applications.stream()
+                .map(Application::getId)
+                .toList();
+        List<ProcessResult> processResults = processResultRepository.findAllByProcessId(process.getId(), applicationIds);
+        return processResults.stream()
+                .collect(Collectors.toMap(ProcessResult::getApplicationId, ProcessResult::getStatus));
+    }
+
+    public List<UUID> findAllApplicationIds(Process process, Status status) {
+        List<ProcessResult> processResults = processResultRepository.findAllByProcessIdAndStatus(process.getId(), status);
+        return processResults.stream()
+                .map(ProcessResult::getApplicationId)
+                .toList();
+    }
+
+    public ProcessResult findCurrentResult(Application application) {
+        Process process = application.getProcess();
+        return processResultRepository.findByApplicationIdAndProcessId(application.getId(), process.getId())
+                .orElse(ProcessResult.getBeforeEvaluationResult(application.getId(), process.getId()));
+    }
+
+    public List<ProcessResult> find(Application application) {
+        long processId = application.getProcess().getId();
+        List<ProcessResult> processResults = processResultRepository.findAllByApplicationIdAndProcessIdIsLessThanEqual(application.getId(), processId);
+        
+        ProcessResult currentProcessResult = processResults.stream()
+                .filter(processResult -> processResult.getProcessId() == processId)
+                .findFirst()
+                .orElse(ProcessResult.getBeforeEvaluationResult(application.getId(), processId));
+
+        if (!processResults.contains(currentProcessResult)) {
+            processResults.add(currentProcessResult);
+        }
+
+        return processResults;
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/domain/service/ProcessResultSaveService.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/service/ProcessResultSaveService.java
@@ -1,0 +1,24 @@
+package com.yoyomo.domain.application.domain.service;
+
+import com.yoyomo.domain.application.domain.entity.Application;
+import com.yoyomo.domain.application.domain.entity.ProcessResult;
+import com.yoyomo.domain.application.domain.repository.ProcessResultRepository;
+import com.yoyomo.domain.recruitment.domain.entity.Process;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProcessResultSaveService {
+
+    private final ProcessResultRepository processResultRepository;
+
+    public ProcessResult save(Application application, Process process) {
+        ProcessResult processResult = ProcessResult.builder()
+                .applicationId(application.getId())
+                .processId(process.getId())
+                .build();
+
+        return processResultRepository.save(processResult);
+    }
+}


### PR DESCRIPTION
## 🚀 PR 요약
프로세스별로 평가상태를 다르게 관리하기 위한 작업입니다.
Application의 Status 대신, ProcessResult의 Status를 사용하도록 변경했습니다.
테이블 변경(추가) 결정 과정은 이슈를 참고해주시면 감사하겠습니다.


## ✨ PR 상세 내용

아래에서 find 메서드는 현재 프로세스가 없는 경우 BeforeEvaluationResult를 추가적으로 넣어주고 있습니다.

application의 모든 processResult를 조회하고 findCurrentResult 반환값을 add 해도 동일한 결과를 낼 수 있으나, DB 연결이 한 번 더 발생한다는 단점이 있습니다.

그래서 현재 구현은 현재 프로세스보다 작거나 같은(이전) 프로세스의 processResult를 모두 찾아 현재 프로세스가 있는지 확인 후 없다면 BeforeEvaluationResult를 추가함으로써 쿼리가 한 번 더 발생하지 않도록 했습니다.

저는 코드의 복잡도보다 쿼리 감소가 경제적이라 생각해 현재 방법을 선택했습니다. 각 방법에 대한 여러분의 의견이 궁금합니다.

```java
public ProcessResult findCurrentResult(Application application) {
    Process process = application.getProcess();
    return processResultRepository.findByApplicationIdAndProcessId(application.getId(), process.getId())
            .orElse(ProcessResult.getBeforeEvaluationResult(application.getId(), process.getId()));
}

public List<ProcessResult> find(Application application) {
    long processId = application.getProcess().getId();
    List<ProcessResult> processResults = processResultRepository.findAllByApplicationIdAndProcessIdIsLessThanEqual(application.getId(), processId);
    
    ProcessResult currentProcessResult = processResults.stream()
            .filter(processResult -> processResult.getProcessId() == processId)
            .findFirst()
            .orElse(ProcessResult.getBeforeEvaluationResult(application.getId(), processId));

    if (!processResults.contains(currentProcessResult)) {
        processResults.add(currentProcessResult);
    }

    return processResults;
}
```

## 🚨 주의 사항

@hyxklee 
Mail 관련 부분에서 processResult를 꺼내오는 로직을 추가하다 수정한 부분이 있습니다. 기존 로직과 차이가 없는지 확인 부탁드립니다

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?


close #311  