### PR TITLE
CRA-113 모집 삭제 구현

### DIFF
--- a/src/main/java/com/yoyomo/domain/application/domain/repository/ApplicationRepository.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/repository/ApplicationRepository.java
@@ -5,16 +5,15 @@ import com.yoyomo.domain.application.domain.entity.enums.Status;
 import com.yoyomo.domain.application.domain.repository.dto.ProcessApplicant;
 import com.yoyomo.domain.recruitment.domain.entity.Process;
 import com.yoyomo.domain.user.domain.entity.User;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 
 public interface ApplicationRepository extends JpaRepository<Application, UUID> {
@@ -68,4 +67,9 @@ public interface ApplicationRepository extends JpaRepository<Application, UUID> 
     void updateProcess(@Param("applicationIds") List<UUID> applicationIds,
                        @Param("process") Process process,
                        @Param("status") Status status);
+
+    @Modifying
+    @Query("DELETE FROM Application a WHERE a.recruitmentId = :recruitmentId")
+    void deleteAllByRecruitmentId(UUID recruitmentId);
+    
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/service/ApplicationDeleteService.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/service/ApplicationDeleteService.java
@@ -1,0 +1,16 @@
+package com.yoyomo.domain.application.domain.service;
+
+import com.yoyomo.domain.application.domain.repository.ApplicationRepository;
+import com.yoyomo.domain.recruitment.domain.entity.Recruitment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationDeleteService {
+    private final ApplicationRepository applicationRepository;
+
+    public void deleteByRecruitmentId(Recruitment recruitment) {
+        applicationRepository.deleteAllByRecruitmentId(recruitment.getId());
+    }
+}

--- a/src/main/java/com/yoyomo/domain/form/application/usecase/FormManageUseCaseImpl.java
+++ b/src/main/java/com/yoyomo/domain/form/application/usecase/FormManageUseCaseImpl.java
@@ -1,5 +1,7 @@
 package com.yoyomo.domain.form.application.usecase;
 
+import static java.util.Collections.emptyList;
+
 import com.yoyomo.domain.club.domain.entity.Club;
 import com.yoyomo.domain.club.domain.service.ClubGetService;
 import com.yoyomo.domain.club.domain.service.ClubManagerAuthService;
@@ -15,6 +17,7 @@ import com.yoyomo.domain.form.domain.repository.dto.LinkedRecruitment;
 import com.yoyomo.domain.form.domain.service.FormGetService;
 import com.yoyomo.domain.form.domain.service.FormSaveService;
 import com.yoyomo.domain.form.domain.service.FormUpdateService;
+import com.yoyomo.domain.form.exception.FormUnmodifiableException;
 import com.yoyomo.domain.item.application.dto.res.ItemResponse;
 import com.yoyomo.domain.item.application.mapper.ItemResponseFactory;
 import com.yoyomo.domain.item.application.usecase.ItemManageUseCase;
@@ -23,15 +26,12 @@ import com.yoyomo.domain.recruitment.domain.entity.Recruitment;
 import com.yoyomo.domain.recruitment.domain.service.RecruitmentGetService;
 import com.yoyomo.domain.user.domain.entity.User;
 import com.yoyomo.domain.user.domain.service.UserGetService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-
-import static java.util.Collections.emptyList;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -99,7 +99,14 @@ public class FormManageUseCaseImpl implements FormManageUseCase {
     @Override
     public void delete(String formId, Long userId) {
         checkAuthorityByFormId(userId, formId);
+        checkIsLinked(formId);
         formUpdateService.delete(formId);
+    }
+
+    private void checkIsLinked(String formId) {
+        if (!(recruitmentGetService.findAllLinkedRecruitments(formId).isEmpty())) {
+            throw new FormUnmodifiableException();
+        }
     }
 
     @Override

--- a/src/main/java/com/yoyomo/domain/form/application/usecase/FormManageUseCaseImpl.java
+++ b/src/main/java/com/yoyomo/domain/form/application/usecase/FormManageUseCaseImpl.java
@@ -17,7 +17,6 @@ import com.yoyomo.domain.form.domain.repository.dto.LinkedRecruitment;
 import com.yoyomo.domain.form.domain.service.FormGetService;
 import com.yoyomo.domain.form.domain.service.FormSaveService;
 import com.yoyomo.domain.form.domain.service.FormUpdateService;
-import com.yoyomo.domain.form.exception.FormUnmodifiableException;
 import com.yoyomo.domain.item.application.dto.res.ItemResponse;
 import com.yoyomo.domain.item.application.mapper.ItemResponseFactory;
 import com.yoyomo.domain.item.application.usecase.ItemManageUseCase;
@@ -99,14 +98,7 @@ public class FormManageUseCaseImpl implements FormManageUseCase {
     @Override
     public void delete(String formId, Long userId) {
         checkAuthorityByFormId(userId, formId);
-        checkIsLinked(formId);
         formUpdateService.delete(formId);
-    }
-
-    private void checkIsLinked(String formId) {
-        if (!(recruitmentGetService.findAllLinkedRecruitments(formId).isEmpty())) {
-            throw new FormUnmodifiableException();
-        }
     }
 
     @Override

--- a/src/main/java/com/yoyomo/domain/recruitment/application/usecase/RecruitmentManageUseCase.java
+++ b/src/main/java/com/yoyomo/domain/recruitment/application/usecase/RecruitmentManageUseCase.java
@@ -6,6 +6,7 @@ import static com.yoyomo.domain.recruitment.application.dto.request.RecruitmentR
 import static com.yoyomo.domain.recruitment.application.dto.response.RecruitmentResponseDTO.DetailResponse;
 import static com.yoyomo.domain.recruitment.application.dto.response.RecruitmentResponseDTO.Response;
 
+import com.yoyomo.domain.application.domain.service.ApplicationDeleteService;
 import com.yoyomo.domain.club.domain.entity.Club;
 import com.yoyomo.domain.club.domain.service.ClubGetService;
 import com.yoyomo.domain.club.domain.service.ClubManagerAuthService;
@@ -15,6 +16,7 @@ import com.yoyomo.domain.form.domain.service.FormGetService;
 import com.yoyomo.domain.recruitment.application.dto.response.ProcessResponseDTO;
 import com.yoyomo.domain.recruitment.domain.entity.Process;
 import com.yoyomo.domain.recruitment.domain.entity.Recruitment;
+import com.yoyomo.domain.recruitment.domain.service.ProcessDeleteService;
 import com.yoyomo.domain.recruitment.domain.service.RecruitmentDeleteService;
 import com.yoyomo.domain.recruitment.domain.service.RecruitmentGetService;
 import com.yoyomo.domain.recruitment.domain.service.RecruitmentSaveService;
@@ -47,6 +49,9 @@ public class RecruitmentManageUseCase {
     private final ClubManagerAuthService clubManagerAuthService;
 
     private final ProcessManageUseCase processManageUseCase;
+    private final ProcessDeleteService processDeleteService;
+
+    private final ApplicationDeleteService applicationDeleteService;
 
     @Transactional
     public void save(Save dto, Long userId) {
@@ -101,6 +106,9 @@ public class RecruitmentManageUseCase {
     @Transactional
     public void cancel(String recruitmentId, Long userId) {
         Recruitment recruitment = checkAuthorityByRecruitment(recruitmentId, userId);
+
+        applicationDeleteService.deleteByRecruitmentId(recruitment);
+        processDeleteService.deleteAllByRecruitment(recruitment);
         recruitmentDeleteService.delete(recruitment);
     }
 

--- a/src/main/java/com/yoyomo/domain/recruitment/domain/repository/ProcessRepository.java
+++ b/src/main/java/com/yoyomo/domain/recruitment/domain/repository/ProcessRepository.java
@@ -2,14 +2,15 @@ package com.yoyomo.domain.recruitment.domain.repository;
 
 import com.yoyomo.domain.recruitment.domain.entity.Process;
 import com.yoyomo.domain.recruitment.domain.entity.Recruitment;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProcessRepository extends JpaRepository<Process, Long> {
 
     Optional<Process> findByRecruitmentAndStage(Recruitment recruitment, Integer stage);
 
     List<Process> findAllByRecruitment(Recruitment recruitment);
+
+    void deleteAllByRecruitment(Recruitment recruitment);
 }

--- a/src/main/java/com/yoyomo/domain/recruitment/domain/service/ProcessDeleteService.java
+++ b/src/main/java/com/yoyomo/domain/recruitment/domain/service/ProcessDeleteService.java
@@ -1,11 +1,11 @@
 package com.yoyomo.domain.recruitment.domain.service;
 
 import com.yoyomo.domain.recruitment.domain.entity.Process;
+import com.yoyomo.domain.recruitment.domain.entity.Recruitment;
 import com.yoyomo.domain.recruitment.domain.repository.ProcessRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -15,5 +15,9 @@ public class ProcessDeleteService {
 
     public void deleteAll(List<Process> processes) {
         processRepository.deleteAllInBatch(processes);
+    }
+
+    public void deleteAllByRecruitment(Recruitment recruitment) {
+        processRepository.deleteAllByRecruitment(recruitment);
     }
 }

--- a/src/main/java/com/yoyomo/domain/recruitment/presentation/RecruitmentController.java
+++ b/src/main/java/com/yoyomo/domain/recruitment/presentation/RecruitmentController.java
@@ -1,5 +1,18 @@
 package com.yoyomo.domain.recruitment.presentation;
 
+import static com.yoyomo.domain.recruitment.application.dto.request.RecruitmentRequestDTO.Save;
+import static com.yoyomo.domain.recruitment.application.dto.request.RecruitmentRequestDTO.Update;
+import static com.yoyomo.domain.recruitment.application.dto.response.RecruitmentResponseDTO.DetailResponse;
+import static com.yoyomo.domain.recruitment.presentation.constant.ResponseMessage.SUCCESS_ACTIVATE;
+import static com.yoyomo.domain.recruitment.presentation.constant.ResponseMessage.SUCCESS_CANCEL;
+import static com.yoyomo.domain.recruitment.presentation.constant.ResponseMessage.SUCCESS_DELETE;
+import static com.yoyomo.domain.recruitment.presentation.constant.ResponseMessage.SUCCESS_MOVE_PROCESS_STEP;
+import static com.yoyomo.domain.recruitment.presentation.constant.ResponseMessage.SUCCESS_READ;
+import static com.yoyomo.domain.recruitment.presentation.constant.ResponseMessage.SUCCESS_READ_PROCESSES;
+import static com.yoyomo.domain.recruitment.presentation.constant.ResponseMessage.SUCCESS_SAVE;
+import static com.yoyomo.domain.recruitment.presentation.constant.ResponseMessage.SUCCESS_UPDATE;
+import static org.springframework.http.HttpStatus.OK;
+
 import com.yoyomo.domain.recruitment.application.dto.response.ProcessResponseDTO;
 import com.yoyomo.domain.recruitment.application.dto.response.RecruitmentResponseDTO.Response;
 import com.yoyomo.domain.recruitment.application.usecase.ProcessManageUseCase;
@@ -11,19 +24,20 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-import java.util.UUID;
-
-import static com.yoyomo.domain.recruitment.application.dto.request.RecruitmentRequestDTO.Save;
-import static com.yoyomo.domain.recruitment.application.dto.request.RecruitmentRequestDTO.Update;
-import static com.yoyomo.domain.recruitment.application.dto.response.RecruitmentResponseDTO.DetailResponse;
-import static com.yoyomo.domain.recruitment.presentation.constant.ResponseMessage.*;
-import static org.springframework.http.HttpStatus.OK;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "RECRUITMENT")
 @RestController
@@ -53,7 +67,8 @@ public class RecruitmentController {
 
     @PatchMapping("/{recruitmentId}/process/{processId}")
     @Operation(summary = "프로세스 스텝 이동(1-2-3)")
-    public ResponseDto<Void> process(@PathVariable UUID recruitmentId, @PathVariable Long processId, @RequestParam ProcessStep step,
+    public ResponseDto<Void> process(@PathVariable UUID recruitmentId, @PathVariable Long processId,
+                                     @RequestParam ProcessStep step,
                                      @CurrentUser @Parameter(hidden = true) Long userId) {
         processManageUseCase.updateStep(recruitmentId, processId, step, userId);
         return ResponseDto.of(OK.value(), SUCCESS_MOVE_PROCESS_STEP.getMessage());
@@ -97,7 +112,7 @@ public class RecruitmentController {
     }
 
     @DeleteMapping("/{recruitmentId}/force")
-    @Operation(summary = "모집 취소")
+    @Operation(summary = "모집 삭제")
     public ResponseDto<Void> cancel(@PathVariable String recruitmentId,
                                     @CurrentUser @Parameter(hidden = true) Long userId) {
         recruitmentManageUseCase.cancel(recruitmentId, userId);


### PR DESCRIPTION
## 🚀 PR 요약

모집 삭제 구현 했습니다

## ✨ PR 상세 내용

1. 기존에 "모집 취소" 라는 이름의 API가 삭제 기능을 하고 있어 이를 모집 삭제로 변경했습니다.
2. 연관관계가 있는 지원서, 프로세스가 함께 삭제되지 않아 API가 정상동작하지 않았습니다 -> 삭제로직 추가


## 🚨 주의 사항

폼 삭제기능은 이미 있어서 구현에서 제외했습니다
삭제를 hard delete로 구현했는데 괜찮을지 의견이 궁금합니다

기능 구현이 우선이라면 이대로 유지 / 그렇지 않다면 엔티티를 변경해야 하는데 -> 이 경우 코드 변경이 너무 많아질 것 같다는 생각입니다

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?

close #313 
