### PR TITLE
CRA-111 토큰 재발급 API 구현 및 필터 경량화

### DIFF
--- a/src/main/java/com/yoyomo/domain/user/application/usecase/UserManageUsecase.java
+++ b/src/main/java/com/yoyomo/domain/user/application/usecase/UserManageUsecase.java
@@ -5,6 +5,7 @@ import com.yoyomo.domain.user.application.mapper.UserMapper;
 import com.yoyomo.domain.user.domain.entity.User;
 import com.yoyomo.domain.user.domain.service.UserGetService;
 import com.yoyomo.domain.user.domain.service.UserSaveService;
+import com.yoyomo.domain.user.exception.UserNotFoundException;
 import com.yoyomo.global.config.jwt.JwtProvider;
 import com.yoyomo.global.config.jwt.presentation.JwtResponse;
 import com.yoyomo.global.config.kakao.KakaoServiceNew;
@@ -12,6 +13,7 @@ import com.yoyomo.global.config.kakao.dto.KakaoAccount;
 import com.yoyomo.global.config.kakao.dto.KakaoTokenResponse;
 import com.yoyomo.global.config.kakao.dto.KakaoUserInfoResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +35,21 @@ public class UserManageUsecase {
         return registerMemberIfNew(userInfo);
     }
 
+    public UserResponseDTO.Response reissueToken(String token) {
+        Pair<Long, String> pair = validateRefreshToken(token);
+
+        long userId = pair.getFirst();
+        String refreshToken = pair.getSecond();
+
+        User user = userGetService.find(userId);
+        user.checkRefreshToken(refreshToken);
+
+        JwtResponse tokenDto = getTokenDto(user);
+        user.updateRefreshToken(tokenDto.getRefreshToken());
+
+        return mapper.toResponseDTO(user, tokenDto);
+    }
+
     private UserResponseDTO.Response registerMemberIfNew(KakaoUserInfoResponse userInfo) {
         String email = userInfo.getKakao_account().getEmail();
 
@@ -47,22 +64,34 @@ public class UserManageUsecase {
         User user = mapper.from(account);
         userSaveService.save(user);
 
-        JwtResponse tokenDto = new JwtResponse(
-                jwtProvider.createAccessToken(user.getId(), user.getEmail()),
-                jwtProvider.createRefreshToken()
-        );
+        JwtResponse tokenDto = getTokenDto(user);
 
         return mapper.toResponseDTO(user, tokenDto);
     }
 
     private UserResponseDTO.Response getUserResponse(String email) {
         User user = userGetService.findByEmail(email);
-        JwtResponse tokenDto = new JwtResponse(
-                jwtProvider.createAccessToken(user.getId(), user.getEmail()),
-                jwtProvider.createRefreshToken()
-        );
+
+        JwtResponse tokenDto = getTokenDto(user);
 
         return mapper.toResponseDTO(user, tokenDto);
+    }
+
+    private JwtResponse getTokenDto(User user) {
+        return new JwtResponse(
+                jwtProvider.createAccessToken(user.getId(), user.getEmail()),
+                jwtProvider.createRefreshToken(user.getId())
+        );
+    }
+
+    private Pair<Long, String> validateRefreshToken(String token) {
+        String refreshToken = jwtProvider.extractRefreshToken(token);
+        jwtProvider.validateToken(refreshToken);
+
+        Long userId = jwtProvider.extractId(refreshToken)
+                .orElseThrow(UserNotFoundException::new);
+
+        return Pair.of(userId, refreshToken);
     }
 
 }

--- a/src/main/java/com/yoyomo/domain/user/domain/entity/User.java
+++ b/src/main/java/com/yoyomo/domain/user/domain/entity/User.java
@@ -1,6 +1,7 @@
 package com.yoyomo.domain.user.domain.entity;
 
 import com.yoyomo.global.common.entity.BaseEntity;
+import com.yoyomo.global.config.jwt.exception.InvalidTokenException;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -38,5 +39,11 @@ public class User extends BaseEntity {
 
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
+    }
+
+    public void checkRefreshToken(String refreshToken) {
+        if (!this.refreshToken.equals(refreshToken)) {
+            throw new InvalidTokenException();
+        }
     }
 }

--- a/src/main/java/com/yoyomo/domain/user/presentation/ManagerController.java
+++ b/src/main/java/com/yoyomo/domain/user/presentation/ManagerController.java
@@ -5,13 +5,11 @@ import com.yoyomo.global.common.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.yoyomo.domain.user.application.dto.response.UserResponseDTO.Response;
 import static com.yoyomo.domain.user.presentation.constant.ResponseMessage.SUCCESS_LOGIN;
+import static com.yoyomo.domain.user.presentation.constant.ResponseMessage.SUCCESS_REISSUE_TOKEN;
 import static org.springframework.http.HttpStatus.OK;
 
 @Tag(name = "USER")
@@ -27,5 +25,13 @@ public class ManagerController {
     public ResponseDto<Response> authenticate(@PathVariable String code) {
         Response response = userManageUsecase.authenticate(code);
         return ResponseDto.of(OK.value(), SUCCESS_LOGIN.getMessage(), response);
+    }
+
+    @PostMapping("/refresh")
+    @Operation(summary = "토큰 리프레시 API")
+    public ResponseDto<Response> reissue(@RequestHeader("Authorization-refresh") String refreshToken) {
+        Response response = userManageUsecase.reissueToken(refreshToken);
+
+        return ResponseDto.of(OK.value(), SUCCESS_REISSUE_TOKEN.getMessage(), response);
     }
 }

--- a/src/main/java/com/yoyomo/domain/user/presentation/constant/ResponseMessage.java
+++ b/src/main/java/com/yoyomo/domain/user/presentation/constant/ResponseMessage.java
@@ -16,6 +16,8 @@ public enum ResponseMessage {
     NEED_REGISTER("회원가입이 필요한 유저입니다."),
     DUPLICATE_USERNAME("이미 사용 중인 아이디입니다."),
     ACCESS_DENIED("권한이 없습니다."),
-    ANONYMOUS_USER("인증 정보가 존재하지 않습니다.");
+    ANONYMOUS_USER("인증 정보가 존재하지 않습니다."),
+    SUCCESS_REISSUE_TOKEN("Jwt 토큰 재발급에 성공했습니다.");
+
     private String message;
 }

--- a/src/main/java/com/yoyomo/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/yoyomo/global/config/security/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
                                 .requestMatchers("/applications").permitAll()
                                 .requestMatchers("/results/{clubId}/details").permitAll()
                                 .requestMatchers("/user/login/**").permitAll()
+                                .requestMatchers("/user/refresh").permitAll()
                                 .requestMatchers("/api/notion/**").permitAll()
                                 .requestMatchers("/landing/general-for-react").permitAll()
                                 .requestMatchers("/health-check").permitAll()


### PR DESCRIPTION
## 🚀 PR 요약
- 요구사항에 따라 재발급된 토큰을 바디로 반환할 수 있는 API를 구현했습니다.
- 리프레시 로직이 API로 이전됨에 따라 기존 리프레시 토큰 유무, 재발급을 책임지던 JwtFilter를 경량화해 정말 미세한 성능개선을 이뤘습니다. [약 1~2ms 정도]
<img width="465" alt="image" src="https://github.com/user-attachments/assets/0e0ed887-f1c5-414c-a4d9-f7937836f11e" />


## ✨ PR 상세 내용
- 토큰 재발급 API 구현
- filter에서 리프레시 관련 로직 제거
- Pair 객체를 이용해 간단하게 한 쌍의 데이터 가져오기 -> 간편하게 사용하기 좋아보여서 사용했습니다. 해당 객체 사용에 대한 여러분의 의견도 궁금해요

```
{
    "result": {
        "code": 200,
        "message": "Jwt 토큰 재발급에 성공했습니다.",
        "data": {
            "id": 1,
            "name": "이강혁",
            "email": "ewgt1234@naver.com",
            "token": {
                "accessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUx9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsImlkIjoxLCJleHAiOjkyMjMzODk0MTU2ODA2NywiZW1haWiJld2d0MTIzNEBuYXZlci5jb20ifQ.zBxZU9PAzc1CjHkFEGU0S_mP6B0P1N7HCO9g3bPDi_hkOWYr6rFHZUC8aZULEpRwlBEyw0DLJzMSAQauPTw",
                "refreshToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJSyZXNoVG9rZW4iLCJpZCI6MSwiZXhwIjoxNzM4NDg3MzkwfQ.TeE39o_C8ZQH-bPdervZmEIEw8Tyr-SHj1H9szJyScMXZnaUBLwV2VKj3m_qtyHdVEJfv_oF_kVoJL1jhgQ"
            }
        }
    }
}
```

<img width="573" alt="image" src="https://github.com/user-attachments/assets/085d6d01-326a-491a-a5f3-819c4933ae31" />


## 🚨 주의 사항
- API 테스트와 리프레시 점검은 모두 완료 했습니다. 다른 문제가 있을지 봐주세요
- 필터가 좀 보기 불편하게 나오던데 전부 확장을 해서 봐주시면 좋을 것 같아요

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
