### PR TITLE
CRA-123 면접 프로세스에서 합격자 이동이 가능하게 변경

### DIFF
--- a/src/main/java/com/yoyomo/domain/recruitment/domain/entity/Process.java
+++ b/src/main/java/com/yoyomo/domain/recruitment/domain/entity/Process.java
@@ -1,17 +1,29 @@
 package com.yoyomo.domain.recruitment.domain.entity;
 
+import static com.yoyomo.domain.recruitment.presentation.constant.ResponseMessage.CANNOT_UPDATE_TO_EVALUATION_STEP;
+import static com.yoyomo.domain.recruitment.presentation.constant.ResponseMessage.PROCESS_STEP_CANNOT_UPDATE;
+
 import com.yoyomo.domain.mail.exception.MailAlreadySentException;
 import com.yoyomo.domain.mail.exception.MailNotScheduledException;
 import com.yoyomo.domain.recruitment.domain.entity.enums.ProcessStep;
 import com.yoyomo.domain.recruitment.domain.entity.enums.Type;
 import com.yoyomo.domain.recruitment.exception.ProcessStepUnModifiableException;
 import com.yoyomo.global.common.entity.BaseEntity;
-import jakarta.persistence.*;
-import lombok.*;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
-
-import static com.yoyomo.domain.recruitment.presentation.constant.ResponseMessage.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
@@ -84,10 +96,6 @@ public class Process extends BaseEntity {
 
         if (step == ProcessStep.EVALUATION && this.isAfterMailSent()) {
             throw new ProcessStepUnModifiableException(CANNOT_UPDATE_TO_EVALUATION_STEP);
-        }
-
-        if (this.type == Type.INTERVIEW && step == ProcessStep.MOVING) {
-            throw new ProcessStepUnModifiableException(CANNOT_UPDATE_TO_MOVING_STEP);
         }
     }
 


### PR DESCRIPTION
## 🚀 PR 요약

면접 프로세스에서 합격자 이동이 가능하게 코드를 수정했습니다

## ✨ PR 상세 내용

checkMovable에서 면접 프로세스인 경우 예외를 터뜨리는 코드를 삭제했습니다.

## 🚨 주의 사항

없습니다!

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
