### PR TITLE
CRA-122 홍보페이지 성능 개선

### DIFF
--- a/src/main/java/com/yoyomo/domain/club/exception/UnavailableSubdomainException.java
+++ b/src/main/java/com/yoyomo/domain/club/exception/UnavailableSubdomainException.java
@@ -1,9 +1,15 @@
 package com.yoyomo.domain.club.exception;
 
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
 import com.yoyomo.global.config.exception.ApplicationException;
 
 public class UnavailableSubdomainException extends ApplicationException {
     public UnavailableSubdomainException(Integer value, String message) {
         super(value, message);
+    }
+
+    public UnavailableSubdomainException(String message) {
+        super(INTERNAL_SERVER_ERROR.value(), message);
     }
 }

--- a/src/main/java/com/yoyomo/global/common/aop/LoggingAspect.java
+++ b/src/main/java/com/yoyomo/global/common/aop/LoggingAspect.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 @Aspect
 public class LoggingAspect {
 
-    @Pointcut("execution(public * com.yoyomo.infra.aws.usecase.DistributeUsecase.createRecord(..))")
+    @Pointcut("execution(public * com.yoyomo.infra.aws.usecase.DistributeUsecase.create(..))")
     private void logForDistributeMethod() {
     }
 

--- a/src/main/java/com/yoyomo/global/common/aop/LoggingAspect.java
+++ b/src/main/java/com/yoyomo/global/common/aop/LoggingAspect.java
@@ -12,24 +12,46 @@ import org.springframework.stereotype.Component;
 @Aspect
 public class LoggingAspect {
 
-    @Pointcut("execution(public * com.yoyomo.infra.aws.usecase.DistributeUsecase.*(..))")
+    @Pointcut("execution(public * com.yoyomo.infra.aws.usecase.DistributeUsecase.createRecord(..))")
     private void logForDistributeMethod() {
     }
 
     @Around("logForDistributeMethod()")
-    public Object logDistrubuteUsecaseExecution(ProceedingJoinPoint joinPoint) throws Throwable {
+    public Object logDistributeUsecaseExecution(ProceedingJoinPoint joinPoint) throws Throwable {
         String methodName = joinPoint.getSignature().toShortString();
         Object[] methodArgs = joinPoint.getArgs();
 
-        log.info("🚀 {} Starting execution of {}", methodArgs[0].toString(), methodName);
+        String subDomain = methodArgs.length > 0 ? methodArgs[0].toString() : "N/A";
 
-        long startTime = System.currentTimeMillis();
+        log.info("🚀 Starting execution of {} with subDomain: {}", methodName, subDomain);
 
-        Object result = joinPoint.proceed();
-
-        long executionTime = System.currentTimeMillis() - startTime;
-        log.info("✅ {} Finished execution {} in {} ms ", result, methodName, executionTime);
+        Object result;
+        try {
+            result = joinPoint.proceed();
+            log.info("✅ Finished execution of {} with subDomain: {}", methodName, subDomain);
+        } catch (Exception e) {
+            log.error("❌ Error executing {} with subDomain: {}: {}", methodName, subDomain, e.getMessage(), e);
+            throw e;
+        }
 
         return result;
+    }
+
+    @Pointcut("execution(* com.yoyomo.infra.aws.s3.service.S3Service.upload(..)) && args(subDomain)")
+    private void logForS3Upload(String subDomain) {
+    }
+
+    @Around("logForS3Upload(subDomain)")
+    public Object logS3UploadExecution(ProceedingJoinPoint joinPoint, String subDomain) throws Throwable {
+        log.info("📂 Uploading to S3 for subdomain: {}", subDomain);
+
+        try {
+            Object result = joinPoint.proceed();
+            log.info("✅ Successfully uploaded to S3 for subdomain: {}", subDomain);
+            return result;
+        } catch (Exception e) {
+            log.error("❌ Failed to upload for subdomain: {} - Error: {}", subDomain, e.getMessage(), e);
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/yoyomo/global/config/async/AsyncConfig.java
+++ b/src/main/java/com/yoyomo/global/config/async/AsyncConfig.java
@@ -12,9 +12,9 @@ public class AsyncConfig {
     @Bean
     public TaskExecutor taskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(4);
-        executor.setMaxPoolSize(10);
-        executor.setQueueCapacity(50);
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(10);
         executor.setThreadNamePrefix("AsyncExecutor-");
         executor.initialize();
         return executor;

--- a/src/main/java/com/yoyomo/global/config/async/AsyncConfig.java
+++ b/src/main/java/com/yoyomo/global/config/async/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.yoyomo.global.config.async;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+    @Bean
+    public TaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("AsyncExecutor-");
+        executor.initialize();
+        return executor;
+    }
+}
+

--- a/src/main/java/com/yoyomo/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/yoyomo/global/config/redis/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
 @Configuration
 public class RedisConfig {
 
@@ -42,6 +43,19 @@ public class RedisConfig {
         redisTemplate.setConnectionFactory(redisConnectionFactory());
 
         return redisTemplate;
+    }
+
+    @Bean(name = "queueRedisTemplate")
+    public RedisTemplate<String, String> queueRedisTemplate(RedisConnectionFactory connectionFactory) {
+        LettuceConnectionFactory queueConnectionFactory = new LettuceConnectionFactory();
+        queueConnectionFactory.setDatabase(1);
+        queueConnectionFactory.afterPropertiesSet();
+
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(queueConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
     }
 
 }

--- a/src/main/java/com/yoyomo/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/yoyomo/global/config/redis/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.yoyomo.global.config.redis;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -45,7 +46,8 @@ public class RedisConfig {
         return redisTemplate;
     }
 
-    @Bean(name = "queueRedisTemplate")
+    @Bean
+    @Qualifier("queueRedisTemplate")
     public RedisTemplate<String, String> queueRedisTemplate() {
         LettuceConnectionFactory queueConnectionFactory = new LettuceConnectionFactory();
         queueConnectionFactory.setDatabase(1);
@@ -57,5 +59,4 @@ public class RedisConfig {
         template.setValueSerializer(new StringRedisSerializer());
         return template;
     }
-
 }

--- a/src/main/java/com/yoyomo/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/yoyomo/global/config/redis/RedisConfig.java
@@ -46,7 +46,7 @@ public class RedisConfig {
     }
 
     @Bean(name = "queueRedisTemplate")
-    public RedisTemplate<String, String> queueRedisTemplate(RedisConnectionFactory connectionFactory) {
+    public RedisTemplate<String, String> queueRedisTemplate() {
         LettuceConnectionFactory queueConnectionFactory = new LettuceConnectionFactory();
         queueConnectionFactory.setDatabase(1);
         queueConnectionFactory.afterPropertiesSet();

--- a/src/main/java/com/yoyomo/infra/aws/usecase/DistributeUsecase.java
+++ b/src/main/java/com/yoyomo/infra/aws/usecase/DistributeUsecase.java
@@ -34,7 +34,7 @@ public class DistributeUsecase {
 
     }
 
-    public void createRecord(String subDomain) {
+    private void createRecord(String subDomain) {
         String distributeId = cloudfrontService.create(subDomain);
         String cloudfrontDomainName = cloudfrontService.getCloudfrontDomainName(distributeId);
 

--- a/src/main/java/com/yoyomo/infra/aws/usecase/DistributeUsecase.java
+++ b/src/main/java/com/yoyomo/infra/aws/usecase/DistributeUsecase.java
@@ -7,6 +7,7 @@ import com.yoyomo.infra.aws.route53.service.Route53Service;
 import com.yoyomo.infra.aws.s3.service.S3Service;
 import com.yoyomo.infra.redis.RedisQueueService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,7 +19,8 @@ public class DistributeUsecase {
     private final RedisQueueService redisQueueService;
     private final String BASEURL = ".crayon.land";
 
-    public String create(String subDomain) {
+    @Async
+    public void create(String subDomain) {
         checkValidSubdomain(subDomain);
 
         String fullSubDomain = subDomain + BASEURL;
@@ -30,10 +32,9 @@ public class DistributeUsecase {
         // route53 레코드 생성
         createRecord(fullSubDomain);
 
-        return subDomain;
     }
 
-    private void createRecord(String subDomain) {
+    public void createRecord(String subDomain) {
         String distributeId = cloudfrontService.create(subDomain);
         String cloudfrontDomainName = cloudfrontService.getCloudfrontDomainName(distributeId);
 

--- a/src/main/java/com/yoyomo/infra/aws/usecase/DistributeUsecase.java
+++ b/src/main/java/com/yoyomo/infra/aws/usecase/DistributeUsecase.java
@@ -3,10 +3,9 @@ package com.yoyomo.infra.aws.usecase;
 import com.yoyomo.domain.club.exception.DuplicatedSubDomainException;
 import com.yoyomo.infra.aws.cloudfront.Service.CloudfrontService;
 import com.yoyomo.infra.aws.constant.ReservedSubDomain;
-import com.yoyomo.infra.aws.exception.FileNotFoundException;
 import com.yoyomo.infra.aws.route53.service.Route53Service;
 import com.yoyomo.infra.aws.s3.service.S3Service;
-import java.io.IOException;
+import com.yoyomo.infra.redis.RedisQueueService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +15,7 @@ public class DistributeUsecase {
     private final S3Service s3Service;
     private final CloudfrontService cloudfrontService;
     private final Route53Service route53Service;
+    private final RedisQueueService redisQueueService;
     private final String BASEURL = ".crayon.land";
 
     public String create(String subDomain) {
@@ -25,23 +25,12 @@ public class DistributeUsecase {
         //버킷 생성
         s3Service.createBucket(fullSubDomain);
 
+        redisQueueService.enqueueUpload(subDomain);
+
         // route53 레코드 생성
         createRecord(fullSubDomain);
 
-        // S3에 next app 업로드
-        tryUpload(subDomain);
-
         return subDomain;
-    }
-
-    private void tryUpload(String subDomain) {
-        String fullSubDomain = subDomain + BASEURL;
-        try {
-            s3Service.upload(fullSubDomain);
-        } catch (IOException e) {
-            delete(subDomain);
-            throw new FileNotFoundException();
-        }
     }
 
     private void createRecord(String subDomain) {

--- a/src/main/java/com/yoyomo/infra/redis/RedisQueueService.java
+++ b/src/main/java/com/yoyomo/infra/redis/RedisQueueService.java
@@ -1,0 +1,26 @@
+package com.yoyomo.infra.redis;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RedisQueueService {
+    private static final String QUEUE_NAME = "uploadQueue";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public RedisQueueService(@Qualifier("queueRedisTemplate") RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void enqueueUpload(String subDomain) {
+        redisTemplate.opsForList().leftPush(QUEUE_NAME, subDomain);
+    }
+
+    public String dequeueUpload() {
+        return redisTemplate.opsForList().rightPop(QUEUE_NAME);
+    }
+}
+
+

--- a/src/main/java/com/yoyomo/infra/redis/RedisQueueService.java
+++ b/src/main/java/com/yoyomo/infra/redis/RedisQueueService.java
@@ -1,6 +1,5 @@
 package com.yoyomo.infra.redis;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -8,18 +7,18 @@ import org.springframework.stereotype.Service;
 public class RedisQueueService {
     private static final String QUEUE_NAME = "uploadQueue";
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisTemplate<String, String> queueRedisTemplate;
 
-    public RedisQueueService(@Qualifier("queueRedisTemplate") RedisTemplate<String, String> redisTemplate) {
-        this.redisTemplate = redisTemplate;
+    public RedisQueueService(RedisTemplate<String, String> queueRedisTemplate) {
+        this.queueRedisTemplate = queueRedisTemplate;
     }
 
     public void enqueueUpload(String subDomain) {
-        redisTemplate.opsForList().leftPush(QUEUE_NAME, subDomain);
+        queueRedisTemplate.opsForList().leftPush(QUEUE_NAME, subDomain);
     }
 
     public String dequeueUpload() {
-        return redisTemplate.opsForList().rightPop(QUEUE_NAME);
+        return queueRedisTemplate.opsForList().rightPop(QUEUE_NAME);
     }
 }
 

--- a/src/main/java/com/yoyomo/infra/redis/RedisQueueWorker.java
+++ b/src/main/java/com/yoyomo/infra/redis/RedisQueueWorker.java
@@ -1,0 +1,32 @@
+package com.yoyomo.infra.redis;
+
+import com.yoyomo.domain.club.exception.UnavailableSubdomainException;
+import com.yoyomo.infra.aws.s3.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisQueueWorker {
+    private final RedisQueueService redisQueueService;
+    private final S3Service s3Service;
+
+    @Scheduled(fixedDelay = 1000)
+    public void processUploadQueue() {
+        while (true) {
+            String subDomain = redisQueueService.dequeueUpload();
+            if (subDomain == null) {
+                break;
+            }
+
+            try {
+                String fullSubDomain = subDomain + ".crayon.land";
+                s3Service.upload(fullSubDomain);
+            } catch (Exception e) {
+                throw new UnavailableSubdomainException(e.getMessage());
+            }
+        }
+    }
+}
+

--- a/src/main/java/com/yoyomo/infra/redis/RedisQueueWorker.java
+++ b/src/main/java/com/yoyomo/infra/redis/RedisQueueWorker.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class RedisQueueWorker {
+    private static final String DOMAIN_FORMAT = "%s.crayon.land";
+    
     private final RedisQueueService redisQueueService;
     private final S3Service s3Service;
 
@@ -21,7 +23,7 @@ public class RedisQueueWorker {
             }
 
             try {
-                String fullSubDomain = subDomain + ".crayon.land";
+                String fullSubDomain = String.format(DOMAIN_FORMAT, subDomain);
                 s3Service.upload(fullSubDomain);
             } catch (Exception e) {
                 throw new UnavailableSubdomainException(e.getMessage());

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -27,6 +27,10 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASS}
+      database: 0
+      queues:
+        database: 1 # 메시지 큐용 데이터베이스
+
   main:
     allow-bean-definition-overriding: true
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,6 +28,9 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASS}
+      database: 0
+      queues:
+        database: 1
   main:
     allow-bean-definition-overriding: true
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -27,6 +27,9 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASS}
+      database: 0
+      queues:
+        database: 1
   main:
     allow-bean-definition-overriding: true
 


### PR DESCRIPTION
## 🚀 PR 요약

홍보페이지 배포 API 성능을 개선했습니다.

## ✨ PR 상세 내용

### 비동기 필요성
홍보페이지 파일 업로드 기능에서 병목이 발생 -> API 응답시간 약 20000ms 이상 소요

### 처리 사항
1. 레디스 큐를 이용하여 파일 업로드를 비동기로 처리했습니다.
2. Async를 이용하여 홍보페이지 배포도 비동기 로직으로 처리했습니다.

### 왜 배포로직과 업로드를 분리했나요?
1. 파일 업로드가 너무 무거운 작업이라고 판단했습니다. 
2. `S3 생성 -> Cloudfront 배포 -> route53` 도메인 생성은 순서대로 작업이 필요하지만
파일 업로드는 S3생성 이후 시점 언제든 업로드 되어도 됩니다.
3. 만약 많은 요청이 동시에 올 경우 배포와 업로드를 별도의 시점에 처리하여 유연하게 배포를 진행할 수 있을 것

배포는 완료되어도 네임서버에 전파되는 시간이 소요되므로 -> "빠르게 업로드가 진행되지 않아도 괜찮다" 라고 생각해서 분리를 진행했습니다.

의견 부탁드려요

### 결과

**큐를 이용하여 업로드만 비동기 처리 했을 때 (7000ms)**

<img width="662" alt="스크린샷 2025-02-01 오후 5 55 14" src="https://github.com/user-attachments/assets/db58a2a2-d8d8-4d55-a238-59c6c45f6893" />


**배포 로직도 `@Async `로 처리했을 때 (143ms)**
<img width="672" alt="스크린샷 2025-01-31 오후 6 44 53" src="https://github.com/user-attachments/assets/d7c43221-04df-4cf6-99e1-efd0f4ec3796" />

**최초 40000ms -> 145ms 로 성능 개선 되었어요**


## 🚨 주의 사항
아직 동시성 해결이 안됐습니다 ㅜ
공부해보도록 할게요, 이 외에 다른 API도 동시성 이슈 거의 해결되지 않아 차차 같이 해결해봐요

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?

close #319 
