### PR TITLE
CRA-135 메일 면접일자 포맷 변경

### DIFF
--- a/src/main/java/com/yoyomo/domain/mail/domain/entity/enums/CustomType.java
+++ b/src/main/java/com/yoyomo/domain/mail/domain/entity/enums/CustomType.java
@@ -2,6 +2,7 @@ package com.yoyomo.domain.mail.domain.entity.enums;
 
 import com.yoyomo.domain.application.domain.entity.Application;
 import com.yoyomo.domain.recruitment.domain.entity.Recruitment;
+import com.yoyomo.global.common.util.DateFormatter;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -33,8 +34,9 @@ public enum CustomType {
     INTERVIEW_DATE("interviewDate") {
         @Override
         public String extractValue(Application application, Recruitment recruitment) {
-            return get(() -> application.getInterview().getDate(), "");
-
+            String date = application.getInterview().getDate();
+            String formattedDate = DateFormatter.formatMailDate(date);
+            return get(() -> formattedDate, "");
         }
     },
     INTERVIEW_PLACE("interviewPlace") {

--- a/src/main/java/com/yoyomo/domain/mail/domain/entity/enums/CustomType.java
+++ b/src/main/java/com/yoyomo/domain/mail/domain/entity/enums/CustomType.java
@@ -21,7 +21,7 @@ public enum CustomType {
     USER_NAME("userName") {
         @Override
         public String extractValue(Application application, Recruitment recruitment) {
-            return get(() -> application.getUser().getName(), "");
+            return get(application::getUserName, "");
         }
     },
     RECRUITMENT_NAME("recruitmentName") {

--- a/src/main/java/com/yoyomo/global/common/util/DateFormatter.java
+++ b/src/main/java/com/yoyomo/global/common/util/DateFormatter.java
@@ -1,0 +1,19 @@
+package com.yoyomo.global.common.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+public class DateFormatter {
+
+    private static final String MAIL_DATE_FORMAT = "M월 d일(E) HH:mm";
+
+    private DateFormatter() {
+    }
+
+    public static String formatMailDate(String date) {
+        LocalDateTime dateTime = LocalDateTime.parse(date);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(MAIL_DATE_FORMAT, Locale.KOREAN);
+        return dateTime.format(formatter);
+    }
+}


### PR DESCRIPTION
## 🚀 PR 요약
메일에서 `2025-02-10T14:00:59` 포맷으로 전달되는 면접일자를 `2월 10일(월) 14:00` 포맷으로 변경합니다.

## ✨ PR 상세 내용
- 날짜 포맷터를 추가했습니다.
  - 유틸성입니다.
- 지원서 유저의 이름이 아닌, 지원자 이름을 가져오도록 변경했습니다. e5e9d5a4fc5048d74957a1f1f47e4ae4f38cf9f8
## 🚨 주의 사항

User의 name이 아닌 지원서의 userName 맞죠..?

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?


close #335 
