### PR TITLE
CRA-141 평가 메모 수정 및 삭제

### DIFF
--- a/src/main/java/com/yoyomo/domain/application/application/usecase/EvaluationManageUseCase.java
+++ b/src/main/java/com/yoyomo/domain/application/application/usecase/EvaluationManageUseCase.java
@@ -13,6 +13,7 @@ import com.yoyomo.domain.application.domain.service.ApplicationUpdateService;
 import com.yoyomo.domain.application.domain.service.EvaluationGetService;
 import com.yoyomo.domain.application.domain.service.EvaluationMemoGetService;
 import com.yoyomo.domain.application.domain.service.EvaluationMemoSaveService;
+import com.yoyomo.domain.application.domain.service.EvaluationMemoUpdateService;
 import com.yoyomo.domain.application.domain.service.EvaluationSaveService;
 import com.yoyomo.domain.application.domain.service.EvaluationUpdateService;
 import com.yoyomo.domain.application.domain.service.ProcessResultGetService;
@@ -39,6 +40,7 @@ public class EvaluationManageUseCase {
     private final EvaluationMemoSaveService evaluationMemoSaveService;
     private final EvaluationMemoGetService evaluationMemoGetService;
     private final ProcessResultGetService processResultGetService;
+    private final EvaluationMemoUpdateService evaluationMemoUpdateService;
 
     @Transactional(readOnly = true)
     public EvaluationResponses findEvaluations(String applicationId, long userId) {
@@ -86,6 +88,12 @@ public class EvaluationManageUseCase {
 
         EvaluationMemo evaluationMemo = request.toEvaluationMemo(manager, application);
         evaluationMemoSaveService.save(evaluationMemo);
+    }
+
+    @Transactional
+    public void deleteMemo(long memoId, long managerId) {
+        User manager = userGetService.find(managerId);
+        evaluationMemoUpdateService.delete(memoId, manager);
     }
 
     @Transactional

--- a/src/main/java/com/yoyomo/domain/application/application/usecase/EvaluationManageUseCase.java
+++ b/src/main/java/com/yoyomo/domain/application/application/usecase/EvaluationManageUseCase.java
@@ -18,6 +18,7 @@ import com.yoyomo.domain.application.domain.service.EvaluationSaveService;
 import com.yoyomo.domain.application.domain.service.EvaluationUpdateService;
 import com.yoyomo.domain.application.domain.service.ProcessResultGetService;
 import com.yoyomo.domain.club.domain.service.ClubManagerAuthService;
+import com.yoyomo.domain.mail.application.usecase.MailManageUseCaseImpl;
 import com.yoyomo.domain.user.domain.entity.User;
 import com.yoyomo.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,7 @@ public class EvaluationManageUseCase {
     private final EvaluationMemoGetService evaluationMemoGetService;
     private final ProcessResultGetService processResultGetService;
     private final EvaluationMemoUpdateService evaluationMemoUpdateService;
+    private final MailManageUseCaseImpl mailManageUseCaseImpl;
 
     @Transactional(readOnly = true)
     public EvaluationResponses findEvaluations(String applicationId, long userId) {
@@ -106,7 +108,6 @@ public class EvaluationManageUseCase {
     @Transactional
     public void updateMemo(long memoId, EvaluationMemoRequest request, long managerId) {
         User manager = userGetService.find(managerId);
-        EvaluationMemo memo = evaluationMemoGetService.findByIdAndManagerAndManager(memoId, manager);
-        memo.update(request.memo());
+        evaluationMemoUpdateService.update(request.memo(), memoId, manager);
     }
 }

--- a/src/main/java/com/yoyomo/domain/application/application/usecase/EvaluationManageUseCase.java
+++ b/src/main/java/com/yoyomo/domain/application/application/usecase/EvaluationManageUseCase.java
@@ -102,4 +102,11 @@ public class EvaluationManageUseCase {
 
         evaluationUpdateService.delete(evaluation, managerId);
     }
+
+    @Transactional
+    public void updateMemo(long memoId, EvaluationMemoRequest request, long managerId) {
+        User manager = userGetService.find(managerId);
+        EvaluationMemo memo = evaluationMemoGetService.findByIdAndManagerAndManager(memoId, manager);
+        memo.update(request.memo());
+    }
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/entity/EvaluationMemo.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/entity/EvaluationMemo.java
@@ -48,4 +48,8 @@ public class EvaluationMemo extends BaseEntity {
     public void delete() {
         this.deletedAt = LocalDateTime.now();
     }
+
+    public void update(String memo) {
+        this.memo = memo;
+    }
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/repository/EvaluationMemoRepository.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/repository/EvaluationMemoRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface EvaluationMemoRepository extends JpaRepository<EvaluationMemo, Long> {
 
@@ -17,8 +16,6 @@ public interface EvaluationMemoRepository extends JpaRepository<EvaluationMemo, 
     @Modifying
     @Query("DELETE FROM EvaluationMemo em WHERE em.id = :memoId AND em.manager = :manager")
     int deleteByIdAndManager(long memoId, User manager);
-
-    Optional<EvaluationMemo> findByIdAndManager(long memoId, User manager);
 
     @Modifying
     @Query("UPDATE EvaluationMemo em SET em.memo = :memo WHERE em.id = :memoId AND em.manager = :manager")

--- a/src/main/java/com/yoyomo/domain/application/domain/repository/EvaluationMemoRepository.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/repository/EvaluationMemoRepository.java
@@ -4,6 +4,8 @@ import com.yoyomo.domain.application.domain.entity.Application;
 import com.yoyomo.domain.application.domain.entity.EvaluationMemo;
 import com.yoyomo.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,7 +14,11 @@ public interface EvaluationMemoRepository extends JpaRepository<EvaluationMemo, 
 
     List<EvaluationMemo> findAllByProcessIdAndApplication(long processId, Application application);
 
-    long deleteByIdAndManager(long memoId, User manager);
+    int deleteByIdAndManager(long memoId, User manager);
 
     Optional<EvaluationMemo> findByIdAndManager(long memoId, User manager);
+
+    @Modifying
+    @Query("UPDATE EvaluationMemo em SET em.memo = :memo WHERE em.id = :memoId AND em.manager = :manager")
+    int updateByIdAndManager(String memo, long memoId, User manager);
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/repository/EvaluationMemoRepository.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/repository/EvaluationMemoRepository.java
@@ -2,11 +2,14 @@ package com.yoyomo.domain.application.domain.repository;
 
 import com.yoyomo.domain.application.domain.entity.Application;
 import com.yoyomo.domain.application.domain.entity.EvaluationMemo;
+import com.yoyomo.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface EvaluationMemoRepository extends JpaRepository<EvaluationMemo, Long> {
-    
+
     List<EvaluationMemo> findAllByProcessIdAndApplication(long processId, Application application);
+
+    long deleteByIdAndManager(long memoId, User manager);
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/repository/EvaluationMemoRepository.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/repository/EvaluationMemoRepository.java
@@ -14,6 +14,8 @@ public interface EvaluationMemoRepository extends JpaRepository<EvaluationMemo, 
 
     List<EvaluationMemo> findAllByProcessIdAndApplication(long processId, Application application);
 
+    @Modifying
+    @Query("DELETE FROM EvaluationMemo em WHERE em.id = :memoId AND em.manager = :manager")
     int deleteByIdAndManager(long memoId, User manager);
 
     Optional<EvaluationMemo> findByIdAndManager(long memoId, User manager);

--- a/src/main/java/com/yoyomo/domain/application/domain/repository/EvaluationMemoRepository.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/repository/EvaluationMemoRepository.java
@@ -6,10 +6,13 @@ import com.yoyomo.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface EvaluationMemoRepository extends JpaRepository<EvaluationMemo, Long> {
 
     List<EvaluationMemo> findAllByProcessIdAndApplication(long processId, Application application);
 
     long deleteByIdAndManager(long memoId, User manager);
+
+    Optional<EvaluationMemo> findByIdAndManager(long memoId, User manager);
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/service/EvaluationMemoGetService.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/service/EvaluationMemoGetService.java
@@ -3,7 +3,9 @@ package com.yoyomo.domain.application.domain.service;
 import com.yoyomo.domain.application.domain.entity.Application;
 import com.yoyomo.domain.application.domain.entity.EvaluationMemo;
 import com.yoyomo.domain.application.domain.repository.EvaluationMemoRepository;
+import com.yoyomo.domain.application.exception.MemoUpdateException;
 import com.yoyomo.domain.recruitment.domain.entity.Process;
+import com.yoyomo.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,5 +21,10 @@ public class EvaluationMemoGetService {
         Process process = application.getProcess();
 
         return evaluationMemoRepository.findAllByProcessIdAndApplication(process.getId(), application);
+    }
+
+    public EvaluationMemo findByIdAndManagerAndManager(long memoId, User manager) {
+        return evaluationMemoRepository.findByIdAndManager(memoId, manager)
+                .orElseThrow(MemoUpdateException::new);
     }
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/service/EvaluationMemoGetService.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/service/EvaluationMemoGetService.java
@@ -3,9 +3,7 @@ package com.yoyomo.domain.application.domain.service;
 import com.yoyomo.domain.application.domain.entity.Application;
 import com.yoyomo.domain.application.domain.entity.EvaluationMemo;
 import com.yoyomo.domain.application.domain.repository.EvaluationMemoRepository;
-import com.yoyomo.domain.application.exception.MemoUpdateException;
 import com.yoyomo.domain.recruitment.domain.entity.Process;
-import com.yoyomo.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,10 +19,5 @@ public class EvaluationMemoGetService {
         Process process = application.getProcess();
 
         return evaluationMemoRepository.findAllByProcessIdAndApplication(process.getId(), application);
-    }
-
-    public EvaluationMemo findByIdAndManagerAndManager(long memoId, User manager) {
-        return evaluationMemoRepository.findByIdAndManager(memoId, manager)
-                .orElseThrow(MemoUpdateException::new);
     }
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/service/EvaluationMemoUpdateService.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/service/EvaluationMemoUpdateService.java
@@ -3,6 +3,7 @@ package com.yoyomo.domain.application.domain.service;
 
 import com.yoyomo.domain.application.domain.repository.EvaluationMemoRepository;
 import com.yoyomo.domain.application.exception.MemoDeleteException;
+import com.yoyomo.domain.application.exception.MemoUpdateException;
 import com.yoyomo.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,13 @@ public class EvaluationMemoUpdateService {
         long executeCount = evaluationMemoRepository.deleteByIdAndManager(memoId, manager);
         if (executeCount != 1) {
             throw new MemoDeleteException();
+        }
+    }
+
+    public void update(String memo, long memoId, User manager) {
+        long executeCount = evaluationMemoRepository.updateByIdAndManager(memo, memoId, manager);
+        if (executeCount != 1) {
+            throw new MemoUpdateException();
         }
     }
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/service/EvaluationMemoUpdateService.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/service/EvaluationMemoUpdateService.java
@@ -1,0 +1,22 @@
+package com.yoyomo.domain.application.domain.service;
+
+
+import com.yoyomo.domain.application.domain.repository.EvaluationMemoRepository;
+import com.yoyomo.domain.application.exception.MemoDeleteException;
+import com.yoyomo.domain.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EvaluationMemoUpdateService {
+
+    private final EvaluationMemoRepository evaluationMemoRepository;
+
+    public void delete(long memoId, User manager) {
+        long executeCount = evaluationMemoRepository.deleteByIdAndManager(memoId, manager);
+        if (executeCount != 1) {
+            throw new MemoDeleteException();
+        }
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/exception/MemoDeleteException.java
+++ b/src/main/java/com/yoyomo/domain/application/exception/MemoDeleteException.java
@@ -1,0 +1,12 @@
+package com.yoyomo.domain.application.exception;
+
+import com.yoyomo.global.config.exception.ApplicationException;
+
+import static com.yoyomo.domain.application.presentation.constant.ResponseMessage.CANNOT_MEMO_DELETE;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+public class MemoDeleteException extends ApplicationException {
+    public MemoDeleteException() {
+        super(NOT_FOUND.value(), CANNOT_MEMO_DELETE.getMessage());
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/exception/MemoUpdateException.java
+++ b/src/main/java/com/yoyomo/domain/application/exception/MemoUpdateException.java
@@ -1,0 +1,12 @@
+package com.yoyomo.domain.application.exception;
+
+import com.yoyomo.global.config.exception.ApplicationException;
+
+import static com.yoyomo.domain.application.presentation.constant.ResponseMessage.CANNOT_MEMO_UPDATE;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+public class MemoUpdateException extends ApplicationException {
+    public MemoUpdateException() {
+        super(NOT_FOUND.value(), CANNOT_MEMO_UPDATE.getMessage());
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/presentation/EvaluationController.java
+++ b/src/main/java/com/yoyomo/domain/application/presentation/EvaluationController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -92,5 +93,14 @@ public class EvaluationController {
         evaluationManageUseCase.createMemo(applicationId, request, userId);
 
         return ResponseDto.of(OK.value(), SUCCESS_SAVE_EVALUATION.getMessage());
+    }
+
+    @DeleteMapping("/memo/{memoId}")
+    @Operation(summary = "평가 메모 삭제")
+    public ResponseDto<Void> deleteMemo(@PathVariable Long memoId,
+                                        @CurrentUser @Parameter(hidden = true) Long userId) {
+        evaluationManageUseCase.deleteMemo(memoId, userId);
+
+        return ResponseDto.of(OK.value(), SUCCESS_DELETE_EVALUATION.getMessage());
     }
 }

--- a/src/main/java/com/yoyomo/domain/application/presentation/EvaluationController.java
+++ b/src/main/java/com/yoyomo/domain/application/presentation/EvaluationController.java
@@ -103,4 +103,14 @@ public class EvaluationController {
 
         return ResponseDto.of(OK.value(), SUCCESS_DELETE_EVALUATION.getMessage());
     }
+
+    @PatchMapping("/memo/{memoId}")
+    @Operation(summary = "평가 메모 수정")
+    public ResponseDto<Void> updateMemo(@PathVariable Long memoId,
+                                        @RequestBody @Valid EvaluationMemoRequest request,
+                                        @CurrentUser @Parameter(hidden = true) Long userId) {
+        evaluationManageUseCase.updateMemo(memoId, request, userId);
+
+        return ResponseDto.of(OK.value(), SUCCESS_UPDATE_EVALUATION.getMessage());
+    }
 }

--- a/src/main/java/com/yoyomo/domain/application/presentation/constant/ResponseMessage.java
+++ b/src/main/java/com/yoyomo/domain/application/presentation/constant/ResponseMessage.java
@@ -36,6 +36,7 @@ public enum ResponseMessage {
     INTERVIEW_RECORD_ALREADY_EXIST("이미 면접 기록 이력이 존재합니다."),
     INTERVIEW_RECORD_NOT_FOUND("면접 기록이 존재하지 않습니다."),
     CANNOT_SELF_DELETE("본인은 삭제할 수 없습니다."),
+    CANNOT_MEMO_DELETE("메모 삭제에 실패했습니다."),
     ACCESS_DENIED("권한이 없습니다."),
     ALREADY_APPLIED("이미 지원한 사용자 입니다.");
     private final String message;

--- a/src/main/java/com/yoyomo/domain/application/presentation/constant/ResponseMessage.java
+++ b/src/main/java/com/yoyomo/domain/application/presentation/constant/ResponseMessage.java
@@ -36,6 +36,7 @@ public enum ResponseMessage {
     INTERVIEW_RECORD_ALREADY_EXIST("이미 면접 기록 이력이 존재합니다."),
     INTERVIEW_RECORD_NOT_FOUND("면접 기록이 존재하지 않습니다."),
     CANNOT_SELF_DELETE("본인은 삭제할 수 없습니다."),
+    CANNOT_MEMO_UPDATE("메모 수정에 실패했습니다."),
     CANNOT_MEMO_DELETE("메모 삭제에 실패했습니다."),
     ACCESS_DENIED("권한이 없습니다."),
     ALREADY_APPLIED("이미 지원한 사용자 입니다.");


### PR DESCRIPTION
## 🚀 PR 요약
메모 수정 및 삭제 기능 추가

## ✨ PR 상세 내용
본인 메모 체크를 쿼리에서 진행했습니다.
메모를 찾아와 수정한다면 (`memo.update(..)`)
memo 값이 불필요함에도 굳이 select 쿼리를 한 번 더 날리기 때문에 해당 방법으로 구현했습니다.

삭제의 경우에도 JPA method를 사용하는 경우 select 쿼리가 발생하는 것을 확인했습니다.
쿼리 실행 개수로 예외 처리를 한 상태이기에 select 없이 delete 하도록 구현했습니다.

## 🚨 주의 사항


## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?

close #345 
