### PR TITLE
CRA-149 jwt 의존성 정리 및 검증 고도화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,10 +44,7 @@ dependencies {
     testAnnotationProcessor "org.mapstruct:mapstruct-processor:1.5.5.Final"
 
     // jwt 추가
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-    implementation 'com.auth0:java-jwt:4.2.1'
+    implementation 'com.auth0:java-jwt:4.5.0'
 
     // 카카오톡 추가
     implementation('org.springframework.boot:spring-boot-starter-oauth2-client') {

--- a/src/main/java/com/yoyomo/domain/user/application/usecase/UserManageUsecase.java
+++ b/src/main/java/com/yoyomo/domain/user/application/usecase/UserManageUsecase.java
@@ -87,11 +87,8 @@ public class UserManageUsecase {
 
     private Pair<Long, String> validateRefreshToken(String token) {
         String refreshToken = jwtProvider.extractRefreshToken(token);
-        jwtProvider.validateToken(refreshToken);
-
         Long userId = jwtProvider.extractId(refreshToken);
 
         return Pair.of(userId, refreshToken);
     }
-
 }

--- a/src/main/java/com/yoyomo/global/common/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/yoyomo/global/common/interceptor/AuthenticationInterceptor.java
@@ -21,7 +21,6 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         }
 
         String accessToken = jwtProvider.extractAccessToken(request);
-        jwtProvider.validateToken(accessToken);
         jwtProvider.extractId(accessToken);
         return true;
     }

--- a/src/main/java/com/yoyomo/global/common/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/yoyomo/global/common/resolver/CurrentUserArgumentResolver.java
@@ -34,7 +34,6 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
                                 WebDataBinderFactory binderFactory) {
         HttpServletRequest httpServletRequest = webRequest.getNativeRequest(HttpServletRequest.class);
         String accessToken = jwtProvider.extractAccessToken(httpServletRequest);
-        jwtProvider.validateToken(accessToken);
         Long id = jwtProvider.extractId(accessToken);
         return userGetService.find(id);
     }

--- a/src/main/java/com/yoyomo/global/config/jwt/JwtProvider.java
+++ b/src/main/java/com/yoyomo/global/config/jwt/JwtProvider.java
@@ -26,6 +26,14 @@ public class JwtProvider {
     private static final String BEARER = "Bearer ";
     private static final int TOKEN_PREFIX_LENGTH = 7;
 
+    private final String key;
+    private final Long accessTokenExpirationPeriod;
+    private final Long refreshTokenExpirationPeriod;
+    private final String accessHeader;
+    private final String refreshHeader;
+    private final JWTVerifier jwtVerifier;
+    private final JWTCreator.Builder jwtBuilder;
+
     public JwtProvider(@Value("${crayon.jwt.key}") String key,
                        @Value("${crayon.jwt.access.expiration}") Long accessTokenExpirationPeriod,
                        @Value("${crayon.jwt.refresh.expiration}") Long refreshTokenExpirationPeriod,
@@ -45,14 +53,6 @@ public class JwtProvider {
         this.jwtBuilder = JWT.create()
                 .withIssuer(issuer);
     }
-
-    private final String key;
-    private final Long accessTokenExpirationPeriod;
-    private final Long refreshTokenExpirationPeriod;
-    private final String accessHeader;
-    private final String refreshHeader;
-    private final JWTVerifier jwtVerifier;
-    private final JWTCreator.Builder jwtBuilder;
 
     public String createAccessToken(Long id) {
         return jwtBuilder

--- a/src/main/java/com/yoyomo/global/config/jwt/JwtProvider.java
+++ b/src/main/java/com/yoyomo/global/config/jwt/JwtProvider.java
@@ -5,7 +5,9 @@ import com.auth0.jwt.JWTCreator;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.yoyomo.global.config.jwt.exception.ExpiredTokenException;
 import com.yoyomo.global.config.jwt.exception.InvalidTokenException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
@@ -89,6 +91,8 @@ public class JwtProvider {
     private DecodedJWT validateToken(String token) {
         try {
             return jwtVerifier.verify(token);
+        } catch (TokenExpiredException e) {
+            throw new ExpiredTokenException();
         } catch (JWTVerificationException e) {
             throw new InvalidTokenException(e);
         }

--- a/src/main/java/com/yoyomo/global/config/jwt/exception/InvalidTokenException.java
+++ b/src/main/java/com/yoyomo/global/config/jwt/exception/InvalidTokenException.java
@@ -1,10 +1,20 @@
 package com.yoyomo.global.config.jwt.exception;
 
 import com.yoyomo.global.config.exception.ApplicationException;
+import lombok.extern.slf4j.Slf4j;
+
 import static com.yoyomo.global.config.jwt.presentation.constant.ResponseMessage.INVALID_TOKEN;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+@Slf4j
 public class InvalidTokenException extends ApplicationException {
+
     public InvalidTokenException() {
-        super(UNAUTHORIZED.value(),INVALID_TOKEN.getMessage());
+        super(UNAUTHORIZED.value(), INVALID_TOKEN.getMessage());
+    }
+
+    public InvalidTokenException(Throwable throwable) {
+        super(UNAUTHORIZED.value(), INVALID_TOKEN.getMessage());
+        log.info("Exception = {}, Message = {}", throwable.getClass(), throwable.getMessage());
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -34,17 +34,6 @@ spring:
   main:
     allow-bean-definition-overriding: true
 
-crayon:
-  jwt:
-    key: ${JWT_ACCESS_SECRET}
-    access:
-      expiration: 922337203685477599
-      header: Authorization
-    refresh:
-      expiration: 604800000
-      header: Authorization-refresh
-    masterToken: ${MASTER_TOKEN}
-
 cloud:
   aws:
     credentials:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -50,3 +50,8 @@ cloud:
 
 vite:
   uri: ${VITE_PUBLIC_API_URL}
+
+crayon:
+  jwt:
+    access:
+      expiration: 922337203685477599

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -34,17 +34,6 @@ spring:
   main:
     allow-bean-definition-overriding: true
 
-crayon:
-  jwt:
-    key: ${JWT_ACCESS_SECRET}
-    access:
-      expiration: 922337203685477599
-      header: Authorization
-    refresh:
-      expiration: 604800000
-      header: Authorization-refresh
-    masterToken: ${MASTER_TOKEN}
-
 cloud:
   aws:
     credentials:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -32,17 +32,6 @@ spring:
   main:
     allow-bean-definition-overriding: true
 
-crayon:
-  jwt:
-    key: ${JWT_ACCESS_SECRET}
-    access:
-      expiration: 922337203685477599
-      header: Authorization
-    refresh:
-      expiration: 604800000
-      header: Authorization-refresh
-    masterToken: ${MASTER_TOKEN}
-
 cloud:
   aws:
     credentials:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,3 +45,14 @@ kakao:
   grant_type: ${KAKAO_GRANT_TYPE}
   client_id: ${KAKAO_CLIENT_ID}
   user_info_uri: ${KAKAO_USER_INFO_URI}
+
+crayon:
+  jwt:
+    key: ${JWT_ACCESS_SECRET}
+    access:
+      expiration: 1800000
+      header: Authorization
+    refresh:
+      expiration: 604800000
+      header: Authorization-refresh
+    issuer: ${JWT_ISSUER}

--- a/src/test/java/com/yoyomo/domain/application/domain/service/InterviewRecordUpdateServiceTest.java
+++ b/src/test/java/com/yoyomo/domain/application/domain/service/InterviewRecordUpdateServiceTest.java
@@ -9,6 +9,7 @@ import com.yoyomo.domain.club.domain.repository.ClubRepository;
 import com.yoyomo.domain.user.domain.entity.User;
 import com.yoyomo.domain.user.domain.repository.UserRepository;
 import com.yoyomo.fixture.TestFixture;
+import com.yoyomo.global.config.jwt.JwtProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -38,6 +40,9 @@ class InterviewRecordUpdateServiceTest {
 
     @Autowired
     InterviewRecordUpdateService interviewRecordUpdateService;
+
+    @MockBean
+    JwtProvider jwtProvider;
 
     User user;
 


### PR DESCRIPTION
## 🚀 PR 요약
- jjwt 의존성 제거
- 토큰 검증 시 id claim, issuer 추가 
- 토큰 예외 구체화

## ✨ PR 상세 내용
- 사용하지 않는 jjwt 라이브러리를 제거하고 [java-jwt](https://github.com/auth0/java-jwt) 유지
- JWT 파싱 메서드 내부에 검증로직 추가
- 여러 yml에서 관리하던 JWT application.yml에서 관리
- 액세스토큰 만료시간 30분으로 변경
- JWTVerifier, JWTCreator.Builder 한 번만 생성
- 토큰 예외 로깅 구체화
  ```
    2025-02-18T22:27:36.609+09:00  INFO 50845 --- [nio-8080-exec-3] c.y.g.c.j.e.InvalidTokenException        : Exception = class com.auth0.jwt.exceptions.MissingClaimException, Message = The Claim 'iss' is not present in the JWT.
    2025-02-18T22:27:36.612+09:00  INFO 50845 --- [nio-8080-exec-3] c.y.g.c.e.GlobalExceptionHandler         : Class = com.yoyomo.global.config.jwt.JwtProvider, Method = validateToken, Message = 유효하지 않은 토큰입니다., Exception Class = com.yoyomo.global.config.jwt.exception.InvalidTokenException
    ```

## 🚨 주의 사항

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?


close #365 
