### PR TITLE
main 머지

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,10 +44,7 @@ dependencies {
     testAnnotationProcessor "org.mapstruct:mapstruct-processor:1.5.5.Final"
 
     // jwt 추가
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-    implementation 'com.auth0:java-jwt:4.2.1'
+    implementation 'com.auth0:java-jwt:4.5.0'
 
     // 카카오톡 추가
     implementation('org.springframework.boot:spring-boot-starter-oauth2-client') {

--- a/src/main/java/com/yoyomo/domain/user/application/usecase/UserManageUsecase.java
+++ b/src/main/java/com/yoyomo/domain/user/application/usecase/UserManageUsecase.java
@@ -87,11 +87,8 @@ public class UserManageUsecase {
 
     private Pair<Long, String> validateRefreshToken(String token) {
         String refreshToken = jwtProvider.extractRefreshToken(token);
-        jwtProvider.validateToken(refreshToken);
-
         Long userId = jwtProvider.extractId(refreshToken);
 
         return Pair.of(userId, refreshToken);
     }
-
 }

--- a/src/main/java/com/yoyomo/global/common/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/yoyomo/global/common/interceptor/AuthenticationInterceptor.java
@@ -21,7 +21,6 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         }
 
         String accessToken = jwtProvider.extractAccessToken(request);
-        jwtProvider.validateToken(accessToken);
         jwtProvider.extractId(accessToken);
         return true;
     }

--- a/src/main/java/com/yoyomo/global/common/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/yoyomo/global/common/resolver/CurrentUserArgumentResolver.java
@@ -34,7 +34,6 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
                                 WebDataBinderFactory binderFactory) {
         HttpServletRequest httpServletRequest = webRequest.getNativeRequest(HttpServletRequest.class);
         String accessToken = jwtProvider.extractAccessToken(httpServletRequest);
-        jwtProvider.validateToken(accessToken);
         Long id = jwtProvider.extractId(accessToken);
         return userGetService.find(id);
     }

--- a/src/main/java/com/yoyomo/global/config/jwt/JwtProvider.java
+++ b/src/main/java/com/yoyomo/global/config/jwt/JwtProvider.java
@@ -1,93 +1,100 @@
 package com.yoyomo.global.config.jwt;
 
 import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTCreator;
+import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.yoyomo.global.config.jwt.exception.ExpiredTokenException;
 import com.yoyomo.global.config.jwt.exception.InvalidTokenException;
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.util.Date;
+import java.time.Instant;
 
 @Slf4j
-@Getter
 @Component
-@RequiredArgsConstructor
 public class JwtProvider {
-    @Value("${crayon.jwt.key}")
-    private String key;
-
-    @Value("${crayon.jwt.access.expiration}")
-    private Long accessTokenExpirationPeriod;
-
-    @Value("${crayon.jwt.refresh.expiration}")
-    private Long refreshTokenExpirationPeriod;
-
-    @Value("${crayon.jwt.access.header}")
-    private String accessHeader;
-
-    @Value("${crayon.jwt.refresh.header}")
-    private String refreshHeader;
 
     private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
     private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
     private static final String ID_CLAIM = "id";
     private static final String BEARER = "Bearer ";
+    private static final int TOKEN_PREFIX_LENGTH = 7;
+
+    private final String key;
+    private final Long accessTokenExpirationPeriod;
+    private final Long refreshTokenExpirationPeriod;
+    private final String accessHeader;
+    private final String refreshHeader;
+    private final JWTVerifier jwtVerifier;
+    private final JWTCreator.Builder jwtBuilder;
+
+    public JwtProvider(@Value("${crayon.jwt.key}") String key,
+                       @Value("${crayon.jwt.access.expiration}") Long accessTokenExpirationPeriod,
+                       @Value("${crayon.jwt.refresh.expiration}") Long refreshTokenExpirationPeriod,
+                       @Value("${crayon.jwt.access.header}") String accessHeader,
+                       @Value("${crayon.jwt.refresh.header}") String refreshHeader,
+                       @Value("${crayon.jwt.issuer}") String issuer
+    ) {
+        this.key = key;
+        this.accessTokenExpirationPeriod = accessTokenExpirationPeriod;
+        this.refreshTokenExpirationPeriod = refreshTokenExpirationPeriod;
+        this.accessHeader = accessHeader;
+        this.refreshHeader = refreshHeader;
+        this.jwtVerifier = JWT.require(Algorithm.HMAC512(key))
+                .withClaimPresence(ID_CLAIM)
+                .withIssuer(issuer)
+                .build();
+        this.jwtBuilder = JWT.create()
+                .withIssuer(issuer);
+    }
 
     public String createAccessToken(Long id) {
-        Date now = new Date();
-        return JWT.create()
-                .withSubject(ACCESS_TOKEN_SUBJECT)
-                .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod))
+        return jwtBuilder
                 .withClaim(ID_CLAIM, id)
+                .withSubject(ACCESS_TOKEN_SUBJECT)
+                .withExpiresAt(Instant.now().plusMillis(accessTokenExpirationPeriod))
                 .sign(Algorithm.HMAC512(key));
     }
 
     public String createRefreshToken(Long id) {
-        Date now = new Date();
-        return JWT.create()
-                .withSubject(REFRESH_TOKEN_SUBJECT)
-                .withExpiresAt(new Date(now.getTime() + refreshTokenExpirationPeriod))
+        return jwtBuilder
                 .withClaim(ID_CLAIM, id)
+                .withSubject(REFRESH_TOKEN_SUBJECT)
+                .withExpiresAt(Instant.now().plusMillis(refreshTokenExpirationPeriod))
                 .sign(Algorithm.HMAC512(key));
     }
 
     public String extractRefreshToken(String token) {
-        return token.replace(BEARER, "");
+        return token.substring(TOKEN_PREFIX_LENGTH);
     }
 
     public String extractAccessToken(HttpServletRequest request) {
         String accessToken = request.getHeader(accessHeader);
         if (accessToken != null && accessToken.startsWith(BEARER)) {
-            return accessToken.replace(BEARER, "");
+            return accessToken.substring(TOKEN_PREFIX_LENGTH);
         }
         throw new InvalidTokenException();
     }
 
     public Long extractId(String accessToken) {
-        try {
-            return JWT.require(Algorithm.HMAC512(key))
-                    .build()
-                    .verify(accessToken)
-                    .getClaim(ID_CLAIM)
-                    .asLong();
-        } catch (Exception e) {
-            throw new InvalidTokenException();
-        }
+        return validateToken(accessToken)
+                .getClaim(ID_CLAIM)
+                .asLong();
     }
 
-    public void validateToken(String token) {
+    private DecodedJWT validateToken(String token) {
         try {
-            JWT.require(Algorithm.HMAC512(key)).build().verify(token);
+            return jwtVerifier.verify(token);
         } catch (TokenExpiredException e) {
             throw new ExpiredTokenException();
-        } catch (Exception e) {
-            throw new InvalidTokenException();
+        } catch (JWTVerificationException e) {
+            throw new InvalidTokenException(e);
         }
     }
 }

--- a/src/main/java/com/yoyomo/global/config/jwt/exception/InvalidTokenException.java
+++ b/src/main/java/com/yoyomo/global/config/jwt/exception/InvalidTokenException.java
@@ -1,10 +1,20 @@
 package com.yoyomo.global.config.jwt.exception;
 
 import com.yoyomo.global.config.exception.ApplicationException;
+import lombok.extern.slf4j.Slf4j;
+
 import static com.yoyomo.global.config.jwt.presentation.constant.ResponseMessage.INVALID_TOKEN;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+@Slf4j
 public class InvalidTokenException extends ApplicationException {
+
     public InvalidTokenException() {
-        super(UNAUTHORIZED.value(),INVALID_TOKEN.getMessage());
+        super(UNAUTHORIZED.value(), INVALID_TOKEN.getMessage());
+    }
+
+    public InvalidTokenException(Throwable throwable) {
+        super(UNAUTHORIZED.value(), INVALID_TOKEN.getMessage());
+        log.info("Exception = {}, Message = {}", throwable.getClass(), throwable.getMessage());
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -34,17 +34,6 @@ spring:
   main:
     allow-bean-definition-overriding: true
 
-crayon:
-  jwt:
-    key: ${JWT_ACCESS_SECRET}
-    access:
-      expiration: 922337203685477599
-      header: Authorization
-    refresh:
-      expiration: 604800000
-      header: Authorization-refresh
-    masterToken: ${MASTER_TOKEN}
-
 cloud:
   aws:
     credentials:
@@ -61,3 +50,8 @@ cloud:
 
 vite:
   uri: ${VITE_PUBLIC_API_URL}
+
+crayon:
+  jwt:
+    access:
+      expiration: 922337203685477599

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -34,17 +34,6 @@ spring:
   main:
     allow-bean-definition-overriding: true
 
-crayon:
-  jwt:
-    key: ${JWT_ACCESS_SECRET}
-    access:
-      expiration: 922337203685477599
-      header: Authorization
-    refresh:
-      expiration: 604800000
-      header: Authorization-refresh
-    masterToken: ${MASTER_TOKEN}
-
 cloud:
   aws:
     credentials:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -32,17 +32,6 @@ spring:
   main:
     allow-bean-definition-overriding: true
 
-crayon:
-  jwt:
-    key: ${JWT_ACCESS_SECRET}
-    access:
-      expiration: 922337203685477599
-      header: Authorization
-    refresh:
-      expiration: 604800000
-      header: Authorization-refresh
-    masterToken: ${MASTER_TOKEN}
-
 cloud:
   aws:
     credentials:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,3 +45,14 @@ kakao:
   grant_type: ${KAKAO_GRANT_TYPE}
   client_id: ${KAKAO_CLIENT_ID}
   user_info_uri: ${KAKAO_USER_INFO_URI}
+
+crayon:
+  jwt:
+    key: ${JWT_ACCESS_SECRET}
+    access:
+      expiration: 1800000
+      header: Authorization
+    refresh:
+      expiration: 604800000
+      header: Authorization-refresh
+    issuer: ${JWT_ISSUER}

--- a/src/test/java/com/yoyomo/domain/application/domain/service/InterviewRecordUpdateServiceTest.java
+++ b/src/test/java/com/yoyomo/domain/application/domain/service/InterviewRecordUpdateServiceTest.java
@@ -9,6 +9,7 @@ import com.yoyomo.domain.club.domain.repository.ClubRepository;
 import com.yoyomo.domain.user.domain.entity.User;
 import com.yoyomo.domain.user.domain.repository.UserRepository;
 import com.yoyomo.fixture.TestFixture;
+import com.yoyomo.global.config.jwt.JwtProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -38,6 +40,9 @@ class InterviewRecordUpdateServiceTest {
 
     @Autowired
     InterviewRecordUpdateService interviewRecordUpdateService;
+
+    @MockBean
+    JwtProvider jwtProvider;
 
     User user;
 


### PR DESCRIPTION
* chore: jjwt 라이브러리 제거

* chore: 환경변수 공통 관리

access-token 유효시간 축소 및 issuer 추가

* refactor: issuer, claim 여부 검증 추가

* refactor: Jwt 빌더 한번만 생성하도록 변경

* feat: 만료 시간 예외 처리

* test: JwtProvider Mock 처리

* refactor: 필드 선언 순서 변경

* feat: dev access token 기한 무제한
