### PR TITLE
CRA-151 request 로깅 필터

### DIFF
--- a/src/main/java/com/yoyomo/global/config/logging/CustomRequestLoggingFilter.java
+++ b/src/main/java/com/yoyomo/global/config/logging/CustomRequestLoggingFilter.java
@@ -1,0 +1,39 @@
+package com.yoyomo.global.config.logging;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.filter.CommonsRequestLoggingFilter;
+
+import java.util.Set;
+
+public class CustomRequestLoggingFilter extends CommonsRequestLoggingFilter {
+
+    private static final Set<String> EXCLUSION_URI_PATTERNS = Set.of(
+            "/swagger-ui",
+            "/swagger-resources",
+            "/v3/api-docs",
+            "/health-check"
+    );
+
+    public CustomRequestLoggingFilter() {
+        setIncludeQueryString(true);
+        setIncludePayload(true);
+        setMaxPayloadLength(10000);
+        setAfterMessagePrefix("[request = ");
+    }
+
+    @Override
+    protected boolean shouldLog(HttpServletRequest request) {
+        String requestURI = request.getRequestURI();
+        return EXCLUSION_URI_PATTERNS.stream()
+                .noneMatch(requestURI::startsWith);
+    }
+
+    @Override
+    protected void beforeRequest(HttpServletRequest request, String message) {
+    }
+
+    @Override
+    protected void afterRequest(HttpServletRequest request, String message) {
+        logger.info(message);
+    }
+}

--- a/src/main/java/com/yoyomo/global/config/logging/RequestLoggingFilterConfig.java
+++ b/src/main/java/com/yoyomo/global/config/logging/RequestLoggingFilterConfig.java
@@ -1,0 +1,16 @@
+package com.yoyomo.global.config.logging;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.CommonsRequestLoggingFilter;
+
+@Slf4j
+@Configuration
+public class RequestLoggingFilterConfig {
+
+    @Bean
+    public CommonsRequestLoggingFilter logFilter() {
+        return new CustomRequestLoggingFilter();
+    }
+}


### PR DESCRIPTION
## 🚀 PR 요약
요청에 대한 로깅 필터를 추가했습니다.

## ✨ PR 상세 내용

스프링에서 지원하는 CommonsRequestLoggingFilter를 사용했습니다. [baeldung 참고](https://www.baeldung.com/spring-http-logging#1-configure-spring-boot-application) 

CommonsRequestLoggingFilter를 사용하면 로깅할 요청 정보를 잘 만들어주기에 사용했습니다.
커스텀으로 따로 만든 것은 BeforeRequest, AfterRequest로 두번 로깅이 찍히는 것이 불필요하다 판단해 Override하여 BeforeRequest는 제외했습니다. (BeforeRequest의 message 파라미터에는 payload가 없어 AfterRequest를 선택했습니다.)



로깅 예시입니다.
```
2025-02-25T22:08:47.386+09:00  INFO 53627 --- [nio-8080-exec-6] c.y.g.config.CustomRequestLoggingFilter  : [request = GET /recruitments/all/aa8b1850-977a-4dc6-bdba-47be06490b4d?page=0&size=7]
2025-02-25T22:13:19.065+09:00  INFO 53627 --- [nio-8080-exec-1] c.y.g.config.CustomRequestLoggingFilter  : [request = POST /evaluations/memo?applicationId=fdee3a33-1278-40a5-8aaf-80e727289a26, payload={
  "memo": "쿨한데요?"
}]
```

## 🚨 주의 사항
모든 경우의 payload를 남기는 게 좋은지 안좋은지 확신이 안섭니다

## ✅ 체크 리스트

- [X] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?


close #370 