### PR TITLE
CRA-156 지원자 수 조회 쿼리 변경 및 메일 템플릿 캐싱

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,9 @@ dependencies {
     implementation 'software.amazon.awssdk:lambda:2.26.4'
 
     runtimeOnly 'com.h2database:h2'
+
+    // spring cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/yoyomo/domain/application/domain/repository/ApplicationRepository.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/repository/ApplicationRepository.java
@@ -59,19 +59,6 @@ public interface ApplicationRepository extends JpaRepository<Application, UUID> 
     Page<ApplicationWithStatus> findAllWithStatusByProcess(@Param("process") Process process, Pageable pageable);
 
     @Query("""
-            SELECT new com.yoyomo.domain.application.domain.repository.dto.ApplicationWithStatus(
-                    a,
-                    pr.status
-                )
-            FROM Application a
-                     LEFT JOIN ProcessResult pr ON a.id = pr.applicationId
-            WHERE a.process = :process OR a.id IN :applicationIds
-            ORDER BY CASE WHEN a.id IN :applicationIds THEN 0 ELSE 1 END,
-                     a.createdAt DESC
-            """)
-    Page<ApplicationWithStatus> findAllByProcess(Process process, List<UUID> applicationIds, Pageable pageable);
-
-    @Query("""
             SELECT new com.yoyomo.domain.application.domain.repository.dto.ProcessApplicant(
                 a.process,
                 COUNT(a.id)

--- a/src/main/java/com/yoyomo/domain/application/domain/service/ApplicationGetService.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/service/ApplicationGetService.java
@@ -2,13 +2,11 @@ package com.yoyomo.domain.application.domain.service;
 
 import com.yoyomo.domain.application.domain.entity.Application;
 import com.yoyomo.domain.application.domain.repository.ApplicationRepository;
-import com.yoyomo.domain.application.domain.repository.ProcessResultRepository;
 import com.yoyomo.domain.application.domain.repository.dto.ApplicationWithStatus;
 import com.yoyomo.domain.application.domain.repository.dto.ProcessApplicant;
 import com.yoyomo.domain.application.exception.ApplicationNotFoundException;
 import com.yoyomo.domain.recruitment.domain.entity.Process;
 import com.yoyomo.domain.user.domain.entity.User;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -25,8 +23,6 @@ import java.util.stream.Collectors;
 public class ApplicationGetService {
 
     private final ApplicationRepository applicationRepository;
-    private final EntityManager entityManager;
-    private final ProcessResultRepository processResultRepository;
 
     public List<Application> findAll(User user) {
         return applicationRepository.findAllByUserAndDeletedAtIsNull(user);
@@ -39,11 +35,6 @@ public class ApplicationGetService {
 
     public Page<ApplicationWithStatus> findAll(Process process, Pageable pageable) {
         return applicationRepository.findAllWithStatusByProcess(process, pageable);
-    }
-
-    public Page<ApplicationWithStatus> findAll2(Process process, Pageable pageable) {
-        List<UUID> applicationIds = processResultRepository.findPendingApplicationId(process.getId());
-        return applicationRepository.findAllByProcess(process, applicationIds, pageable);
     }
 
     public List<Application> findAllOrderByName(Process process) {

--- a/src/main/java/com/yoyomo/domain/recruitment/domain/repository/ProcessRepository.java
+++ b/src/main/java/com/yoyomo/domain/recruitment/domain/repository/ProcessRepository.java
@@ -21,13 +21,13 @@ public interface ProcessRepository extends JpaRepository<Process, Long> {
     @Query("""
              SELECT new com.yoyomo.domain.recruitment.domain.dto.ProcessWithApplicantCount(
                    p,
-                   (SELECT COUNT (a.id)
-                    FROM Application a
-                    WHERE a.process.id = p.id
-                    AND a.deletedAt IS NULL)
+                   COUNT(a.id)
              )
              FROM Process p
+             LEFT JOIN
+                  Application a ON p.id = a.process.id AND a.deletedAt IS NULL
              WHERE p.recruitment.id = :recruitmentId
+             GROUP BY p.stage, p.id
              ORDER BY p.stage
             """)
     List<ProcessWithApplicantCount> findAllWithApplicantCount(UUID recruitmentId);

--- a/src/main/java/com/yoyomo/domain/recruitment/domain/service/ProcessGetService.java
+++ b/src/main/java/com/yoyomo/domain/recruitment/domain/service/ProcessGetService.java
@@ -31,11 +31,6 @@ public class ProcessGetService {
         return processRepository.findAllByRecruitment(recruitment);
     }
 
-    public void exists(Long processId) {
-        processRepository.findById(processId)
-                .orElseThrow(ProcessNotFoundException::new);
-    }
-
     public List<ProcessWithApplicantCount> findAllWithApplicantCount(UUID recruitmentId) {
         return processRepository.findAllWithApplicantCount(recruitmentId);
     }

--- a/src/main/java/com/yoyomo/domain/template/application/dto/response/MailTemplateGetResponse.java
+++ b/src/main/java/com/yoyomo/domain/template/application/dto/response/MailTemplateGetResponse.java
@@ -1,5 +1,6 @@
 package com.yoyomo.domain.template.application.dto.response;
 
+import com.yoyomo.domain.template.application.dto.request.MailTemplateUpdateRequest;
 import com.yoyomo.domain.template.domain.entity.MailTemplate;
 import lombok.Builder;
 import software.amazon.awssdk.services.ses.model.GetTemplateResponse;
@@ -24,6 +25,17 @@ public record MailTemplateGetResponse(
                 .htmlPart(response.template().htmlPart())
                 .textPart(response.template().textPart())
                 .createdAt(mailTemplate.getCreatedAt())
+                .build();
+    }
+
+    public static MailTemplateGetResponse toResponse(MailTemplate mailTemplate, MailTemplateUpdateRequest request) {
+        return MailTemplateGetResponse.builder()
+                .templateId(mailTemplate.getId())
+                .customTemplateName(mailTemplate.getCustomTemplateName())
+                .subject(request.subject())
+                .htmlPart(request.htmlPart())
+                .textPart(request.textPart())
+                .createdAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/yoyomo/domain/template/application/usecase/MailTemplateManageUseCase.java
+++ b/src/main/java/com/yoyomo/domain/template/application/usecase/MailTemplateManageUseCase.java
@@ -14,6 +14,7 @@ import com.yoyomo.domain.template.domain.service.MailTemplateSaveService;
 import com.yoyomo.domain.template.domain.service.MailTemplateUpdateService;
 import com.yoyomo.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -53,10 +54,12 @@ public class MailTemplateManageUseCase {
     }
 
     @Transactional
-    public void update(MailTemplateUpdateRequest dto, UUID templateId, User user) {
+    @CachePut(value = "mailTemplate", key = "#templateId")
+    public MailTemplateGetResponse update(MailTemplateUpdateRequest dto, UUID templateId, User user) {
         MailTemplate mailTemplate = checkAuthorityByMailTemplate(templateId, user);
 
         mailTemplateUpdateService.update(dto, mailTemplate, templateId);
+        return MailTemplateGetResponse.toResponse(mailTemplate, dto);
     }
 
     @Transactional

--- a/src/main/java/com/yoyomo/domain/template/application/usecase/MailTemplateManageUseCase.java
+++ b/src/main/java/com/yoyomo/domain/template/application/usecase/MailTemplateManageUseCase.java
@@ -14,6 +14,7 @@ import com.yoyomo.domain.template.domain.service.MailTemplateSaveService;
 import com.yoyomo.domain.template.domain.service.MailTemplateUpdateService;
 import com.yoyomo.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -46,6 +47,7 @@ public class MailTemplateManageUseCase {
                 .map(MailTemplateListResponse::of);
     }
 
+    @Cacheable(value = "mailTemplate", key = "#templateId")
     public MailTemplateGetResponse find(UUID templateId) {
         return mailTemplateGetService.findWithSes(templateId);
     }

--- a/src/main/java/com/yoyomo/global/config/cache/CachingConfig.java
+++ b/src/main/java/com/yoyomo/global/config/cache/CachingConfig.java
@@ -1,0 +1,19 @@
+package com.yoyomo.global.config.cache;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@EnableCaching
+@Configuration
+public class CachingConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager();
+        cacheManager.setAllowNullValues(false);
+        return cacheManager;
+    }
+}

--- a/src/test/java/com/yoyomo/domain/application/domain/service/InterviewRecordUpdateServiceTest.java
+++ b/src/test/java/com/yoyomo/domain/application/domain/service/InterviewRecordUpdateServiceTest.java
@@ -6,6 +6,7 @@ import com.yoyomo.domain.application.exception.AccessDeniedException;
 import com.yoyomo.domain.club.domain.entity.Club;
 import com.yoyomo.domain.club.domain.repository.ClubMangerRepository;
 import com.yoyomo.domain.club.domain.repository.ClubRepository;
+import com.yoyomo.domain.fixture.CustomRepository;
 import com.yoyomo.domain.fixture.TestFixture;
 import com.yoyomo.domain.user.domain.entity.User;
 import com.yoyomo.domain.user.domain.repository.UserRepository;
@@ -38,6 +39,9 @@ class InterviewRecordUpdateServiceTest {
     @Autowired
     InterviewRecordUpdateService interviewRecordUpdateService;
 
+    @Autowired
+    CustomRepository customRepository;
+
     User user;
 
     @BeforeEach
@@ -49,10 +53,7 @@ class InterviewRecordUpdateServiceTest {
 
     @AfterEach
     void tearDown() {
-        interviewRecordRepository.deleteAll();
-        clubMangerRepository.deleteAll();
-        clubRepository.deleteAll();
-        userRepository.deleteAll();
+        customRepository.clearAndReset();
     }
 
     @DisplayName("면접 기록 작성자라면 삭제에 성공한다.")

--- a/src/test/java/com/yoyomo/domain/fixture/CustomRepository.java
+++ b/src/test/java/com/yoyomo/domain/fixture/CustomRepository.java
@@ -1,20 +1,22 @@
 package com.yoyomo.domain.fixture;
 
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class CustomRepository {
 
-    @PersistenceContext
+    @Autowired
     private EntityManager entityManager;
 
     @Transactional
     public void clearAndReset() {
         entityManager.createNativeQuery("DELETE FROM application").executeUpdate();
+        entityManager.createNativeQuery("DELETE FROM interview_record").executeUpdate();
         entityManager.createNativeQuery("DELETE FROM recruitment").executeUpdate();
+        entityManager.createNativeQuery("DELETE FROM club_manager").executeUpdate();
         entityManager.createNativeQuery("DELETE FROM club").executeUpdate();
         entityManager.createNativeQuery("DELETE FROM user").executeUpdate();
 


### PR DESCRIPTION
## 🚀 PR 요약
- 지원자 수 조회 쿼리 변경 (서브쿼리 → JOIN)
- 메일 템플릿 캐싱
- 필요없는 메서드 삭제

## ✨ PR 상세 내용
- 지원자 수 조회 쿼리 변경 (서브쿼리 → JOIN) ([참고](https://lead-giver-009.notion.site/1-1aaa0085c23780e8a0e2cb7829196be2?pvs=4) ← `더 개선이 필요해: temporary table 쓰지 않기`부터 보면 도움될듯)
  - 기존에 사용했던 방법인데, 프로세스가 3개인 상황에서는 성능이 (미세하게) 조금 안좋았음
  - 이후 프로세스 커스텀이 가능하다면 JOIN 방식이 유리할 것으로 판단 
  - JOIN방식도 커버링 인덱스로 충분히 성능을 높일 수 있다 판단
- 메일 템플릿 캐싱 ([참고](https://lead-giver-009.notion.site/Cache-1b4a0085c237808b916be625e37bcf64?pvs=4))
  - 메일 템플릿을 서버 DB에 저장하지 않고 매번 SES에서 조회
  - 동시 요청자 30명인 경우 16% 오류 발생
  - 캐싱으로 처리
- 필요없는 메서드 삭제

## 🚨 주의 사항
캐싱의 TTL 을 어느정도로 해야할 지 고민이 필요합니다

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?

close #379 