### PR TITLE
CRA-160 메일 전송 일일 수량 제한

### DIFF
--- a/src/main/java/com/yoyomo/domain/mail/exception/MailLimitExceededException.java
+++ b/src/main/java/com/yoyomo/domain/mail/exception/MailLimitExceededException.java
@@ -1,0 +1,11 @@
+package com.yoyomo.domain.mail.exception;
+
+import com.yoyomo.global.config.exception.ApplicationException;
+
+import static org.springframework.http.HttpStatus.TOO_MANY_REQUESTS;
+
+public class MailLimitExceededException extends ApplicationException {
+    public MailLimitExceededException(String message) {
+        super(TOO_MANY_REQUESTS.value(), message);
+    }
+}

--- a/src/main/java/com/yoyomo/domain/mail/presentation/constant/ResponseMessage.java
+++ b/src/main/java/com/yoyomo/domain/mail/presentation/constant/ResponseMessage.java
@@ -18,6 +18,7 @@ public enum ResponseMessage {
     MAIL_NOT_SCHEDULED("예약된 메일이 존재하지 않습니다"),
     MAIL_UPDATE_FAIL("예약시간을 현재 시간 이전으로 수정할 수 없습니다."),
     MAIL_ALREADY_SENT("이미 예약시간을 경과한 메일입니다."),
-    MAIL_STRATEGY_MISMATCH("존재하지 않는 MailStrategy Type 입니다");
+    MAIL_STRATEGY_MISMATCH("존재하지 않는 MailStrategy Type 입니다"),
+    MAIL_LIMIT_EXCEEDED("일일 메일 전송량을 초과했습니다.");
     private final String message;
 }

--- a/src/main/java/com/yoyomo/global/common/MailRateLimiter.java
+++ b/src/main/java/com/yoyomo/global/common/MailRateLimiter.java
@@ -1,0 +1,40 @@
+package com.yoyomo.global.common;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class MailRateLimiter {
+
+    private static final String REMAINING_KEY = "global:email";
+    private static final long MAX_EMAILS_PER_DAY = 50_000;
+    private static final Duration TTL = Duration.ofHours(24);
+
+    private final RedisTemplate<String, String> rateLimitRedisTemplate;
+
+    public boolean isRateLimited(int requestSize) {
+        ValueOperations<String, String> ops = rateLimitRedisTemplate.opsForValue();
+
+        long remaining = getRemaining(ops);
+        if (remaining < requestSize) {
+            return true;
+        }
+
+        ops.decrement(REMAINING_KEY, requestSize);
+        return false;
+    }
+
+    private long getRemaining(ValueOperations<String, String> ops) {
+        String remaining = ops.get(REMAINING_KEY);
+        if (remaining == null) {
+            ops.set(REMAINING_KEY, String.valueOf(MAX_EMAILS_PER_DAY), TTL);
+            return MAX_EMAILS_PER_DAY;
+        }
+        return Long.parseLong(remaining);
+    }
+}

--- a/src/main/java/com/yoyomo/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/yoyomo/global/config/redis/RedisConfig.java
@@ -67,4 +67,24 @@ public class RedisConfig {
         template.setValueSerializer(new StringRedisSerializer());
         return template;
     }
+
+    @Bean
+    public RedisTemplate<String, String> rateLimitRedisTemplate() {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(rateLimitConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+
+    private RedisConnectionFactory rateLimitConnectionFactory() {
+        RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
+        redisConfiguration.setHostName(host);
+        redisConfiguration.setPort(port);
+        redisConfiguration.setPassword(password);
+        redisConfiguration.setDatabase(2);
+        LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(redisConfiguration);
+        lettuceConnectionFactory.afterPropertiesSet();
+        return lettuceConnectionFactory;
+    }
 }

--- a/src/test/java/com/yoyomo/domain/mail/application/usecase/MailManageUseCaseImplTest.java
+++ b/src/test/java/com/yoyomo/domain/mail/application/usecase/MailManageUseCaseImplTest.java
@@ -1,0 +1,92 @@
+package com.yoyomo.domain.mail.application.usecase;
+
+import com.yoyomo.domain.ApplicationTest;
+import com.yoyomo.global.common.MailRateLimiter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MailManageUseCaseImplTest extends ApplicationTest {
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOps;
+
+    @InjectMocks
+    private MailRateLimiter mailRateLimiter;
+
+    private static final String REDIS_KEY = "global:email";
+
+    @BeforeEach
+    void setup() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    }
+
+    @DisplayName("발신 한도 제한을 넘지 않으면 참을 반환한다.")
+    @Test
+    void isRateLimited_whenRemainIsFull() {
+        // given
+        when(valueOps.get(REDIS_KEY)).thenReturn("50000");
+        when(valueOps.decrement(REDIS_KEY)).thenReturn(49_999L);
+
+        // when
+        boolean isExceeded = mailRateLimiter.isRateLimited(1);
+
+        // then
+        assertThat(isExceeded).isFalse();
+    }
+
+    @DisplayName("발신 한도가 없으면 새롭게 한도를 설정한다.")
+    @Test
+    void isRateLimited_whenRemainIsNull() {
+        // given
+        when(valueOps.get(REDIS_KEY)).thenReturn(null);
+        when(valueOps.decrement(REDIS_KEY)).thenReturn(49_999L);
+
+        // when
+        boolean isExceeded = mailRateLimiter.isRateLimited(1);
+
+        // then
+        verify(valueOps).set(eq(REDIS_KEY), eq("50000"), eq(Duration.ofHours(24)));
+        assertThat(isExceeded).isFalse();
+    }
+
+    @DisplayName("발신 한도에 걸리면 거짓을 반환한다.")
+    @Test
+    void isRateLimited_whenRemainIsZero() {
+        // given
+        when(valueOps.get(REDIS_KEY)).thenReturn("0");
+
+        // when
+        boolean isExceeded = mailRateLimiter.isRateLimited(1);
+
+        // then
+        assertThat(isExceeded).isTrue();
+    }
+
+    @DisplayName("현재 발신 요청량이 남은 한도보다 크다면 거짓을 반환한다.")
+    @Test
+    void isRateLimited_whenRemainIsLessThanRequest() {
+        // given
+        when(valueOps.get(REDIS_KEY)).thenReturn("10");
+
+        // when
+        boolean isExceeded = mailRateLimiter.isRateLimited(11);
+
+        // then
+        assertThat(isExceeded).isTrue();
+    }
+}


### PR DESCRIPTION
## 🚀 PR 요약
기존에는 요청 제한을 두려했으나, API 호출 수가 아닌 메일 전송량에 한도가 있어 메일 전송 수에 대한 제한을 두는 방향으로 구현했습니다

## ✨ PR 상세 내용
- Redis를 사용해 한도를 제한했습니다.
  - 일일 총 사용량 50,000건
  - 일일 동아리 사용량 300건
- 한도를 넘어서면 예외를 던집니다.


## 🚨 주의 사항
- 동아리 사용량은 임의로 정한 것이라 조정에 열려있습니다.
- 예약 전송의 경우, 예약 일자에 대해 한도를 측정해야하는데, 이 부분은 아직 시도하지 못했습니다.
- 

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [ ] Label 설정했나요?
- [ ] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
