### PR TITLE
CRA-162 외부 지원서 가져오기

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -49,6 +49,13 @@ jobs:
       # gradle 빌드
       - name: Build with Gradle Wrapper
         run: ./gradlew build
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          junit_files: '**/build/test-results/test/TEST-*.xml'
+
   deploy:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -50,11 +50,11 @@ jobs:
       - name: Build with Gradle Wrapper
         run: ./gradlew build
 
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v5
+        if: success() || failure() # always run even if the previous step fails
         with:
-          junit_files: '**/build/test-results/test/TEST-*.xml'
+          report_paths: '**/build/test-results/test/TEST-*.xml'
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -17,6 +17,16 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      mongo:
+        image: mongo:6.0
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongo --eval 'db.runCommand({ ping: 1 })' --quiet"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     permissions:
       contents: read
     steps:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -22,7 +22,7 @@ jobs:
         ports:
           - 27017:27017
         options: >-
-          --health-cmd "mongo --eval 'db.runCommand({ ping: 1 })' --quiet"
+          --health-cmd "mongosh --eval 'db.adminCommand({ ping: 1 })' --quiet"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -29,6 +29,8 @@ jobs:
 
     permissions:
       contents: read
+      checks: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,16 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      mongo:
+        image: mongo:6.0
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongo --eval 'db.runCommand({ ping: 1 })' --quiet"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     permissions:
       contents: read
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         ports:
           - 27017:27017
         options: >-
-          --health-cmd "mongo --eval 'db.runCommand({ ping: 1 })' --quiet"
+          --health-cmd "mongosh --eval 'db.adminCommand({ ping: 1 })' --quiet"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/src/main/java/com/yoyomo/domain/application/application/dto/request/ApplicationImportRequest.java
+++ b/src/main/java/com/yoyomo/domain/application/application/dto/request/ApplicationImportRequest.java
@@ -1,0 +1,24 @@
+package com.yoyomo.domain.application.application.dto.request;
+
+import com.yoyomo.domain.application.domain.model.Question;
+import com.yoyomo.domain.application.domain.model.Replies;
+
+import java.util.List;
+
+public record ApplicationImportRequest(
+        List<QuestionRequest> cols,
+        List<RespondentRequest> rows
+) {
+
+    public List<Question> toQuestions() {
+        return cols.stream()
+                .map(col -> new Question(col.label(), col.type()))
+                .toList();
+    }
+
+    public List<Replies> toAnswers() {
+        return rows.stream()
+                .map(RespondentRequest::toAnswers)
+                .toList();
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/application/dto/request/ApplicationImportRequest.java
+++ b/src/main/java/com/yoyomo/domain/application/application/dto/request/ApplicationImportRequest.java
@@ -16,7 +16,7 @@ public record ApplicationImportRequest(
                 .toList();
     }
 
-    public List<Replies> toAnswers() {
+    public List<Replies> toReplies() {
         return rows.stream()
                 .map(RespondentRequest::toAnswers)
                 .toList();

--- a/src/main/java/com/yoyomo/domain/application/application/dto/request/DataRequest.java
+++ b/src/main/java/com/yoyomo/domain/application/application/dto/request/DataRequest.java
@@ -1,0 +1,12 @@
+package com.yoyomo.domain.application.application.dto.request;
+
+import com.yoyomo.domain.application.domain.model.Reply;
+
+public record DataRequest(
+        String v
+) {
+
+    public Reply toAnswer() {
+        return new Reply(v);
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/application/dto/request/QuestionRequest.java
+++ b/src/main/java/com/yoyomo/domain/application/application/dto/request/QuestionRequest.java
@@ -1,0 +1,7 @@
+package com.yoyomo.domain.application.application.dto.request;
+
+public record QuestionRequest(
+        String label,
+        String type
+) {
+}

--- a/src/main/java/com/yoyomo/domain/application/application/dto/request/RespondentRequest.java
+++ b/src/main/java/com/yoyomo/domain/application/application/dto/request/RespondentRequest.java
@@ -1,0 +1,18 @@
+package com.yoyomo.domain.application.application.dto.request;
+
+import com.yoyomo.domain.application.domain.model.Replies;
+import com.yoyomo.domain.application.domain.model.Reply;
+
+import java.util.List;
+
+public record RespondentRequest(
+        List<DataRequest> c
+) {
+
+    public Replies toAnswers() {
+        List<Reply> replies = c.stream()
+                .map(DataRequest::toAnswer)
+                .toList();
+        return new Replies(replies);
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/application/usecase/ApplicationImportUseCase.java
+++ b/src/main/java/com/yoyomo/domain/application/application/usecase/ApplicationImportUseCase.java
@@ -1,0 +1,41 @@
+package com.yoyomo.domain.application.application.usecase;
+
+import com.yoyomo.domain.application.application.dto.request.ApplicationImportRequest;
+import com.yoyomo.domain.application.domain.entity.Application;
+import com.yoyomo.domain.application.domain.model.ApplicantReply;
+import com.yoyomo.domain.application.domain.model.Question;
+import com.yoyomo.domain.application.domain.model.Replies;
+import com.yoyomo.domain.application.domain.service.AnswerSaveService;
+import com.yoyomo.domain.application.domain.service.ApplicationSaveService;
+import com.yoyomo.domain.club.domain.service.ClubManagerAuthService;
+import com.yoyomo.domain.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApplicationImportUseCase {
+
+    private final ApplicationSaveService applicationSaveService;
+    private final AnswerSaveService answerSaveService;
+    private final ClubManagerAuthService clubManagerAuthService;
+
+    public void importApplications(UUID recruitmentId, User user, ApplicationImportRequest request) {
+        clubManagerAuthService.checkAuthorization(recruitmentId, user);
+
+        List<Question> questions = request.toQuestions();
+        List<Replies> answers = request.toAnswers();
+
+        List<ApplicantReply> applicantReplies = answers.stream()
+                .map(answer -> ApplicantReply.toApplicantReply(questions, answer))
+                .toList();
+
+        List<Application> applications = applicationSaveService.saveAll(recruitmentId, applicantReplies);
+        answerSaveService.save(applicantReplies, applications);
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/application/usecase/ApplicationImportUseCase.java
+++ b/src/main/java/com/yoyomo/domain/application/application/usecase/ApplicationImportUseCase.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class ApplicationImportUseCase {
 
@@ -24,7 +25,6 @@ public class ApplicationImportUseCase {
     private final AnswerSaveService answerSaveService;
     private final ClubManagerAuthService clubManagerAuthService;
 
-    @Transactional
     public void importApplications(UUID recruitmentId, User user, ApplicationImportRequest request) {
         clubManagerAuthService.checkAuthorization(recruitmentId, user);
 

--- a/src/main/java/com/yoyomo/domain/application/application/usecase/ApplicationImportUseCase.java
+++ b/src/main/java/com/yoyomo/domain/application/application/usecase/ApplicationImportUseCase.java
@@ -10,13 +10,12 @@ import com.yoyomo.domain.application.domain.service.ApplicationSaveService;
 import com.yoyomo.domain.club.domain.service.ClubManagerAuthService;
 import com.yoyomo.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ApplicationImportUseCase {
@@ -25,26 +24,18 @@ public class ApplicationImportUseCase {
     private final AnswerSaveService answerSaveService;
     private final ClubManagerAuthService clubManagerAuthService;
 
-import org.springframework.transaction.annotation.Transactional;
+    @Transactional
+    public void importApplications(UUID recruitmentId, User user, ApplicationImportRequest request) {
+        clubManagerAuthService.checkAuthorization(recruitmentId, user);
 
-@Transactional
-public void importApplications(UUID recruitmentId, User user, ApplicationImportRequest request) {
-    clubManagerAuthService.checkAuthorization(recruitmentId, user);
+        List<Question> questions = request.toQuestions();
+        List<Replies> replies = request.toReplies();
 
-    List<Question> questions = request.toQuestions();
-    List<Replies> replies = request.toReplies();
+        List<ApplicantReply> applicantReplies = replies.stream()
+                .map(reply -> ApplicantReply.of(questions, reply))
+                .toList();
 
-    List<ApplicantReply> applicantReplies = replies.stream()
-            .map(reply -> ApplicantReply.of(questions, reply))
-            .toList();
-
-    try {
         List<Application> applications = applicationSaveService.saveAll(recruitmentId, applicantReplies);
         answerSaveService.save(applicantReplies, applications);
-        log.info("Successfully imported {} applications for recruitment {}", applications.size(), recruitmentId);
-    } catch (Exception e) {
-        log.error("Failed to import applications for recruitment {}", recruitmentId, e);
-        throw new ApplicationImportException("Failed to import applications", e);
     }
-}
 }

--- a/src/main/java/com/yoyomo/domain/application/application/usecase/ApplicationImportUseCase.java
+++ b/src/main/java/com/yoyomo/domain/application/application/usecase/ApplicationImportUseCase.java
@@ -29,10 +29,10 @@ public class ApplicationImportUseCase {
         clubManagerAuthService.checkAuthorization(recruitmentId, user);
 
         List<Question> questions = request.toQuestions();
-        List<Replies> answers = request.toAnswers();
+        List<Replies> replies = request.toReplies();
 
-        List<ApplicantReply> applicantReplies = answers.stream()
-                .map(answer -> ApplicantReply.toApplicantReply(questions, answer))
+        List<ApplicantReply> applicantReplies = replies.stream()
+                .map(reply -> ApplicantReply.of(questions, reply))
                 .toList();
 
         List<Application> applications = applicationSaveService.saveAll(recruitmentId, applicantReplies);

--- a/src/main/java/com/yoyomo/domain/application/domain/entity/Application.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/entity/Application.java
@@ -61,6 +61,11 @@ public class Application extends BaseEntity {
 
     private LocalDateTime deletedAt;
 
+    public UUID generateId() {
+        this.id = UUID.randomUUID();
+        return id;
+    }
+
     public void update(Process process) {
         this.process = process;
     }

--- a/src/main/java/com/yoyomo/domain/application/domain/model/Applicant.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/model/Applicant.java
@@ -2,12 +2,20 @@ package com.yoyomo.domain.application.domain.model;
 
 import lombok.AllArgsConstructor;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @AllArgsConstructor
 public class Applicant {
 
     private final Map<ApplicantInfo, Reply> values;
+
+    public static Applicant from(List<QuestionReply> questionReplies) {
+        Map<ApplicantInfo, Reply> applicantInfos = questionReplies.stream()
+                .collect(Collectors.toMap(ApplicantInfo::find, QuestionReply::getReply));
+        return new Applicant(applicantInfos);
+    }
 
     public String getName() {
         return values.getOrDefault(ApplicantInfo.NAME, Reply.empty()).value();

--- a/src/main/java/com/yoyomo/domain/application/domain/model/Applicant.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/model/Applicant.java
@@ -1,0 +1,23 @@
+package com.yoyomo.domain.application.domain.model;
+
+import lombok.AllArgsConstructor;
+
+import java.util.Map;
+
+@AllArgsConstructor
+public class Applicant {
+
+    private final Map<ApplicantInfo, Reply> values;
+
+    public String getName() {
+        return values.getOrDefault(ApplicantInfo.NAME, Reply.empty()).value();
+    }
+
+    public String getPhone() {
+        return values.getOrDefault(ApplicantInfo.PHONE, Reply.empty()).value();
+    }
+
+    public String getEmail() {
+        return values.getOrDefault(ApplicantInfo.EMAIL, Reply.empty()).value();
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/domain/model/ApplicantInfo.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/model/ApplicantInfo.java
@@ -1,5 +1,6 @@
 package com.yoyomo.domain.application.domain.model;
 
+import com.yoyomo.domain.application.exception.InvalidApplicantInfoException;
 import lombok.AllArgsConstructor;
 
 import java.util.Arrays;
@@ -16,7 +17,7 @@ public enum ApplicantInfo {
         return Arrays.stream(values())
                 .filter(info -> questionReply.match(info.keyword))
                 .findFirst()
-                .orElseThrow(); // todo: 예외처리
+                .orElseThrow(InvalidApplicantInfoException::new);
     }
 
     public static boolean anyMatch(String title) {

--- a/src/main/java/com/yoyomo/domain/application/domain/model/ApplicantInfo.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/model/ApplicantInfo.java
@@ -1,0 +1,26 @@
+package com.yoyomo.domain.application.domain.model;
+
+import lombok.AllArgsConstructor;
+
+import java.util.Arrays;
+
+@AllArgsConstructor
+public enum ApplicantInfo {
+    NAME("이름"),
+    PHONE("전화번호"),
+    EMAIL("메일");
+
+    private final String keyword;
+
+    public static ApplicantInfo find(Question question) {
+        return Arrays.stream(values())
+                .filter(info -> question.match(info.keyword))
+                .findFirst()
+                .orElseThrow(); // todo: 예외처리
+    }
+
+    public static boolean anyMatch(String title) {
+        return Arrays.stream(values())
+                .anyMatch(info -> title.contains(info.keyword));
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/domain/model/ApplicantInfo.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/model/ApplicantInfo.java
@@ -12,9 +12,9 @@ public enum ApplicantInfo {
 
     private final String keyword;
 
-    public static ApplicantInfo find(Question question) {
+    public static ApplicantInfo find(QuestionReply questionReply) {
         return Arrays.stream(values())
-                .filter(info -> question.match(info.keyword))
+                .filter(info -> questionReply.match(info.keyword))
                 .findFirst()
                 .orElseThrow(); // todo: 예외처리
     }

--- a/src/main/java/com/yoyomo/domain/application/domain/model/ApplicantReply.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/model/ApplicantReply.java
@@ -2,6 +2,7 @@ package com.yoyomo.domain.application.domain.model;
 
 import com.yoyomo.domain.application.domain.entity.Application;
 import com.yoyomo.domain.item.domain.entity.Item;
+import com.yoyomo.domain.recruitment.domain.entity.Process;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -21,7 +22,7 @@ public class ApplicantReply {
 
     /**
      * 질문 목록과 답변 목록으로부터 ApplicantReply 객체를 생성합니다.
-     * 질문과 답변을 인덱스별로 매칭하고, 지원자 정보(이름, 전화번호, 이메일)와 
+     * 질문과 답변을 인덱스별로 매칭하고, 지원자 정보(이름, 전화번호, 이메일)와
      * 일반 질문 답변으로 분리합니다.
      *
      * @param questions 질문 목록
@@ -54,12 +55,13 @@ public class ApplicantReply {
         return QuestionReply.of(question, reply);
     }
 
-    public Application toApplication(UUID recruitmentId) {
+    public Application toApplication(UUID recruitmentId, Process process) {
         return Application.builder()
                 .userName(applicant.getName())
                 .tel(applicant.getPhone())
                 .email(applicant.getEmail())
                 .recruitmentId(recruitmentId)
+                .process(process)
                 .build(); // todo: 프로세스 추가해야하나
     }
 

--- a/src/main/java/com/yoyomo/domain/application/domain/model/ApplicantReply.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/model/ApplicantReply.java
@@ -1,6 +1,7 @@
 package com.yoyomo.domain.application.domain.model;
 
 import com.yoyomo.domain.application.domain.entity.Application;
+import com.yoyomo.domain.application.exception.QuestionReplySizeMismatchException;
 import com.yoyomo.domain.item.domain.entity.Item;
 import com.yoyomo.domain.recruitment.domain.entity.Process;
 import lombok.AllArgsConstructor;
@@ -30,9 +31,11 @@ public class ApplicantReply {
      * @return 생성된 ApplicantReply 객체
      */
     public static ApplicantReply of(List<Question> questions, Replies replies) {
-        int length = getLength(questions, replies);
+        if (questions.size() != replies.size()) {
+            throw new QuestionReplySizeMismatchException();
+        }
 
-        Map<Boolean, List<QuestionReply>> partitioned = IntStream.range(0, length)
+        Map<Boolean, List<QuestionReply>> partitioned = IntStream.range(0, questions.size())
                 .mapToObj(i -> toQuestionReply(questions, replies, i))
                 .collect(partitioningBy(QuestionReply::isApplicantInfo));
 
@@ -40,13 +43,6 @@ public class ApplicantReply {
         List<QuestionReply> questionReplyPairs = partitioned.get(false);
 
         return new ApplicantReply(Applicant.from(applicantInfoPairs), questionReplyPairs);
-    }
-
-    private static int getLength(List<Question> questions, Replies replies) {
-        if (questions.size() != replies.size()) {
-            return Math.min(questions.size(), replies.size());
-        }
-        return questions.size();
     }
 
     private static QuestionReply toQuestionReply(List<Question> questions, Replies replies, int i) {
@@ -62,7 +58,7 @@ public class ApplicantReply {
                 .email(applicant.getEmail())
                 .recruitmentId(recruitmentId)
                 .process(process)
-                .build(); // todo: 프로세스 추가해야하나
+                .build();
     }
 
     public List<Item> toAnswers() {

--- a/src/main/java/com/yoyomo/domain/application/domain/model/ApplicantReply.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/model/ApplicantReply.java
@@ -19,6 +19,15 @@ public class ApplicantReply {
     private final Applicant applicant;
     private final List<QuestionReply> questionReplyPairs;
 
+    /**
+     * 질문 목록과 답변 목록으로부터 ApplicantReply 객체를 생성합니다.
+     * 질문과 답변을 인덱스별로 매칭하고, 지원자 정보(이름, 전화번호, 이메일)와 
+     * 일반 질문 답변으로 분리합니다.
+     *
+     * @param questions 질문 목록
+     * @param replies   답변 목록
+     * @return 생성된 ApplicantReply 객체
+     */
     public static ApplicantReply of(List<Question> questions, Replies replies) {
         int length = getLength(questions, replies);
 

--- a/src/main/java/com/yoyomo/domain/application/domain/model/ApplicantReply.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/model/ApplicantReply.java
@@ -1,0 +1,64 @@
+package com.yoyomo.domain.application.domain.model;
+
+import com.yoyomo.domain.application.domain.entity.Application;
+import com.yoyomo.domain.item.domain.entity.Item;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class ApplicantReply {
+
+    private final Applicant applicant;
+    private final List<QuestionReply> questionReplyPairs;
+
+    public static ApplicantReply toApplicantReply(List<Question> questions, Replies replies) {
+        List<Reply> replyList = replies.toList();
+
+        Map<ApplicantInfo, Reply> applicant = new HashMap<>();
+        List<QuestionReply> pairs = new ArrayList<>();
+        for (int i = 0; i < getLength(questions, replyList); i++) {
+            Question question = questions.get(i);
+            Reply reply = replyList.get(i);
+
+            if (question.isApplicantInfo()) {
+                ApplicantInfo info = ApplicantInfo.find(question);
+                applicant.put(info, reply);
+                continue;
+            }
+
+            QuestionReply questionReply = QuestionReply.of(question, reply);
+            pairs.add(questionReply);
+        }
+
+        return new ApplicantReply(new Applicant(applicant), pairs);
+    }
+
+    private static int getLength(List<Question> questions, List<Reply> replies) {
+        if (questions.size() != replies.size()) {
+            return Math.min(questions.size(), replies.size());
+        }
+        return questions.size();
+    }
+
+    public Application toApplication(UUID recruitmentId) {
+        return Application.builder()
+                .userName(applicant.getName())
+                .tel(applicant.getPhone())
+                .email(applicant.getEmail())
+                .recruitmentId(recruitmentId)
+                .build(); // todo: 프로세스 추가해야하나
+    }
+
+    public List<Item> toAnswers() {
+        return questionReplyPairs.stream()
+                .map(QuestionReply::toAnswer)
+                .toList();
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/domain/model/Question.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/model/Question.java
@@ -1,0 +1,26 @@
+package com.yoyomo.domain.application.domain.model;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class Question {
+
+    private final String title;
+    private final String type;
+
+    public boolean isDateType() {
+        return "datetime".equals(type);
+    }
+
+    public boolean isApplicantInfo() {
+        return ApplicantInfo.anyMatch(title);
+    }
+
+    public boolean match(String title) {
+        return this.title.contains(title);
+    }
+
+    public String getTitle() {
+        return title;
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/domain/model/Question.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/model/Question.java
@@ -16,8 +16,8 @@ public class Question {
         return ApplicantInfo.anyMatch(title);
     }
 
-    public boolean match(String title) {
-        return this.title.contains(title);
+    public boolean match(String keyword) {
+        return this.title.contains(keyword);
     }
 
     public String getTitle() {

--- a/src/main/java/com/yoyomo/domain/application/domain/model/QuestionReply.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/model/QuestionReply.java
@@ -17,7 +17,19 @@ public class QuestionReply {
         return new QuestionReply(question, reply);
     }
 
+    public boolean isApplicantInfo() {
+        return question.isApplicantInfo();
+    }
+
     public Item toAnswer() {
         return Answer.of(question.getTitle(), reply.value());
+    }
+
+    public boolean match(String keyword) {
+        return question.match(keyword);
+    }
+
+    public Reply getReply() {
+        return reply;
     }
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/model/QuestionReply.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/model/QuestionReply.java
@@ -1,0 +1,23 @@
+package com.yoyomo.domain.application.domain.model;
+
+import com.yoyomo.domain.item.domain.entity.Answer;
+import com.yoyomo.domain.item.domain.entity.Item;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class QuestionReply {
+
+    private final Question question;
+    private final Reply reply;
+
+    public static QuestionReply of(Question question, Reply reply) {
+        if (!reply.isEmpty() && question.isDateType()) {
+            return new QuestionReply(question, reply.formatDate());
+        }
+        return new QuestionReply(question, reply);
+    }
+
+    public Item toAnswer() {
+        return Answer.of(question.getTitle(), reply.value());
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/domain/model/Replies.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/model/Replies.java
@@ -2,7 +2,6 @@ package com.yoyomo.domain.application.domain.model;
 
 import lombok.AllArgsConstructor;
 
-import java.util.Collections;
 import java.util.List;
 
 @AllArgsConstructor
@@ -14,7 +13,7 @@ public class Replies {
         return replies.size();
     }
 
-    public List<Reply> toList() {
-        return Collections.unmodifiableList(replies);
+    public Reply get(int index) {
+        return replies.get(index);
     }
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/model/Replies.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/model/Replies.java
@@ -1,0 +1,20 @@
+package com.yoyomo.domain.application.domain.model;
+
+import lombok.AllArgsConstructor;
+
+import java.util.Collections;
+import java.util.List;
+
+@AllArgsConstructor
+public class Replies {
+
+    private final List<Reply> replies;
+
+    public int size() {
+        return replies.size();
+    }
+
+    public List<Reply> toList() {
+        return Collections.unmodifiableList(replies);
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/domain/model/Reply.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/model/Reply.java
@@ -1,11 +1,13 @@
 package com.yoyomo.domain.application.domain.model;
 
+import com.yoyomo.domain.application.exception.InvalidDateFormat;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public class Reply {
 
     private static final String DATE_FORMAT = "%s-%s-%s";
+    private static final String DATE_TIME_FORMAT = "%s-%s-%s %s:%s";
 
     private final String value;
 
@@ -19,8 +21,15 @@ public class Reply {
 
     public Reply formatDate() {
         String[] split = value.split(",");
-        String formatted = String.format(DATE_FORMAT, split[0], split[1], split[2]);
-        return new Reply(formatted);
+        if (split.length >= 5) {
+            String formatted = String.format(DATE_TIME_FORMAT, split[0], split[1], split[2], split[3], split[4]);
+            return new Reply(formatted);
+        }
+        if (split.length >= 3) {
+            String formatted = String.format(DATE_FORMAT, split[0], split[1], split[2]);
+            return new Reply(formatted);
+        }
+        throw new InvalidDateFormat();
     }
 
     public String value() {

--- a/src/main/java/com/yoyomo/domain/application/domain/model/Reply.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/model/Reply.java
@@ -1,0 +1,29 @@
+package com.yoyomo.domain.application.domain.model;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class Reply {
+
+    private static final String DATE_FORMAT = "%s-%s-%s";
+
+    private final String value;
+
+    public static Reply empty() {
+        return new Reply("");
+    }
+
+    public boolean isEmpty() {
+        return value == null || value.isEmpty();
+    }
+
+    public Reply formatDate() {
+        String[] split = value.split(",");
+        String formatted = String.format(DATE_FORMAT, split[0], split[1], split[2]);
+        return new Reply(formatted);
+    }
+
+    public String value() {
+        return value;
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/domain/repository/ApplicationJdbcRepository.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/repository/ApplicationJdbcRepository.java
@@ -1,0 +1,64 @@
+package com.yoyomo.domain.application.domain.repository;
+
+import com.yoyomo.domain.application.domain.entity.Application;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.nio.ByteBuffer;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class ApplicationJdbcRepository {
+
+    public static final int BATCH_SIZE = 50;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public List<Application> batchInserts(List<Application> applications) {
+        int total = applications.size();
+
+        for (int start = 0; start < total; start += BATCH_SIZE) {
+            int end = Math.min(start + BATCH_SIZE, total);
+            List<Application> chunk = applications.subList(start, end);
+
+            jdbcTemplate.batchUpdate(
+                    "INSERT INTO application(application_id, user_name, email, tel, recruitment_id) " +
+                            "VALUES (?, ?, ?, ?, ?)",
+                    new BatchPreparedStatementSetter() {
+                        @Override
+                        public void setValues(PreparedStatement ps, int i) throws SQLException {
+                            Application application = chunk.get(i);
+                            UUID applicationId = application.generateId();
+
+                            ps.setBytes(1, uuidToBytes(applicationId));
+                            ps.setString(2, application.getUserName());
+                            ps.setString(3, application.getEmail());
+                            ps.setString(4, application.getTel());
+                            ps.setBytes(5, uuidToBytes(application.getRecruitmentId()));
+                        }
+
+                        @Override
+                        public int getBatchSize() {
+                            return chunk.size();
+                        }
+                    }
+            );
+        }
+
+        return new ArrayList<>(applications);
+    }
+
+    private byte[] uuidToBytes(UUID uuid) {
+        ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+        bb.putLong(uuid.getMostSignificantBits());
+        bb.putLong(uuid.getLeastSignificantBits());
+        return bb.array();
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/domain/repository/ApplicationJdbcRepository.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/repository/ApplicationJdbcRepository.java
@@ -30,8 +30,8 @@ public class ApplicationJdbcRepository {
             List<Application> chunk = applications.subList(start, end);
 
             int[] results = jdbcTemplate.batchUpdate(
-                    "INSERT INTO application(application_id, user_name, email, tel, recruitment_id) " +
-                            "VALUES (?, ?, ?, ?, ?)",
+                    "INSERT INTO application(application_id, user_name, email, tel, recruitment_id, process_id) " +
+                            "VALUES (?, ?, ?, ?, ?, ?)",
                     new BatchPreparedStatementSetter() {
                         @Override
                         public void setValues(PreparedStatement ps, int i) throws SQLException {
@@ -43,6 +43,7 @@ public class ApplicationJdbcRepository {
                             ps.setString(3, application.getEmail());
                             ps.setString(4, application.getTel());
                             ps.setBytes(5, uuidToBytes(application.getRecruitmentId()));
+                            ps.setLong(6, application.getProcess().getId());
                         }
 
                         @Override

--- a/src/main/java/com/yoyomo/domain/application/domain/service/AnswerSaveService.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/service/AnswerSaveService.java
@@ -2,11 +2,15 @@ package com.yoyomo.domain.application.domain.service;
 
 import com.yoyomo.domain.application.application.mapper.AnswerMapper;
 import com.yoyomo.domain.application.domain.entity.Answer;
+import com.yoyomo.domain.application.domain.entity.Application;
+import com.yoyomo.domain.application.domain.model.ApplicantReply;
 import com.yoyomo.domain.application.domain.repository.mongo.AnswerRepository;
 import com.yoyomo.domain.item.domain.entity.Item;
+import com.yoyomo.domain.item.domain.service.factory.ItemFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -16,9 +20,27 @@ public class AnswerSaveService {
 
     private final AnswerMapper answerMapper;
     private final AnswerRepository answerRepository;
+    private final ItemFactory itemFactory;
 
     public Answer save(List<Item> items, UUID applicationId) {
         Answer answer = answerMapper.from(items, applicationId);
         return answerRepository.save(answer);
+    }
+
+    public void save(List<ApplicantReply> applicantReplies, List<Application> applications) {
+        List<Answer> answers = new ArrayList<>();
+        for (int i = 0; i < applicantReplies.size(); i++) {
+            UUID applicationId = applications.get(i).getId();
+            ApplicantReply applicantReply = applicantReplies.get(i);
+
+            Answer answer = Answer.builder()
+                    .applicationId(applicationId.toString())
+                    .items(itemFactory.createItem(applicantReply))
+                    .build();
+
+            answers.add(answer);
+        }
+
+        answerRepository.saveAll(answers);
     }
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/service/ApplicationSaveService.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/service/ApplicationSaveService.java
@@ -2,6 +2,7 @@ package com.yoyomo.domain.application.domain.service;
 
 import com.yoyomo.domain.application.domain.entity.Application;
 import com.yoyomo.domain.application.domain.model.ApplicantReply;
+import com.yoyomo.domain.application.domain.repository.ApplicationJdbcRepository;
 import com.yoyomo.domain.application.domain.repository.ApplicationRepository;
 import com.yoyomo.domain.recruitment.domain.repository.RecruitmentRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class ApplicationSaveService {
 
+    private final ApplicationJdbcRepository applicationJdbcRepository;
     private final ApplicationRepository applicationRepository;
     private final RecruitmentRepository recruitmentRepository;
 
@@ -30,6 +32,6 @@ public class ApplicationSaveService {
                 .toList();
 
         recruitmentRepository.increaseApplicantCount(recruitmentId, applicantReplies.size());
-        return applicationRepository.saveAll(applications);
+        return applicationJdbcRepository.batchInserts(applications);
     }
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/service/ApplicationSaveService.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/service/ApplicationSaveService.java
@@ -32,6 +32,6 @@ public class ApplicationSaveService {
                 .toList();
 
         recruitmentRepository.increaseApplicantCount(recruitmentId, applicantReplies.size());
-        return applicationJdbcRepository.batchInserts(applications);
+        return applicationJdbcRepository.batchInsert(applications);
     }
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/service/ApplicationSaveService.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/service/ApplicationSaveService.java
@@ -4,6 +4,8 @@ import com.yoyomo.domain.application.domain.entity.Application;
 import com.yoyomo.domain.application.domain.model.ApplicantReply;
 import com.yoyomo.domain.application.domain.repository.ApplicationJdbcRepository;
 import com.yoyomo.domain.application.domain.repository.ApplicationRepository;
+import com.yoyomo.domain.recruitment.domain.entity.Process;
+import com.yoyomo.domain.recruitment.domain.entity.Recruitment;
 import com.yoyomo.domain.recruitment.domain.repository.RecruitmentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,8 +29,11 @@ public class ApplicationSaveService {
     }
 
     public List<Application> saveAll(UUID recruitmentId, List<ApplicantReply> applicantReplies) {
+        Recruitment recruitment = recruitmentRepository.findById(recruitmentId).orElseThrow();
+        Process process = recruitment.getDocumentProcess();
+
         List<Application> applications = applicantReplies.stream()
-                .map(ar -> ar.toApplication(recruitmentId))
+                .map(ar -> ar.toApplication(recruitmentId, process))
                 .toList();
 
         recruitmentRepository.increaseApplicantCount(recruitmentId, applicantReplies.size());

--- a/src/main/java/com/yoyomo/domain/application/domain/service/ApplicationSaveService.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/service/ApplicationSaveService.java
@@ -1,24 +1,35 @@
 package com.yoyomo.domain.application.domain.service;
 
 import com.yoyomo.domain.application.domain.entity.Application;
+import com.yoyomo.domain.application.domain.model.ApplicantReply;
 import com.yoyomo.domain.application.domain.repository.ApplicationRepository;
 import com.yoyomo.domain.recruitment.domain.repository.RecruitmentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class ApplicationSaveService {
 
     private final ApplicationRepository applicationRepository;
     private final RecruitmentRepository recruitmentRepository;
 
-    @Transactional
     public Application save(UUID recruitmentId, Application application) {
         recruitmentRepository.increaseApplicantCount(recruitmentId);
         return applicationRepository.save(application);
+    }
+
+    public List<Application> saveAll(UUID recruitmentId, List<ApplicantReply> applicantReplies) {
+        List<Application> applications = applicantReplies.stream()
+                .map(ar -> ar.toApplication(recruitmentId))
+                .toList();
+
+        recruitmentRepository.increaseApplicantCount(recruitmentId, applicantReplies.size());
+        return applicationRepository.saveAll(applications);
     }
 }

--- a/src/main/java/com/yoyomo/domain/application/exception/BatchInsertFailException.java
+++ b/src/main/java/com/yoyomo/domain/application/exception/BatchInsertFailException.java
@@ -1,0 +1,12 @@
+package com.yoyomo.domain.application.exception;
+
+import com.yoyomo.global.config.exception.ApplicationException;
+
+import static com.yoyomo.domain.application.presentation.constant.ResponseMessage.FAILED_BATCH_INSERT;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+public class BatchInsertFailException extends ApplicationException {
+    public BatchInsertFailException() {
+        super(INTERNAL_SERVER_ERROR.value(), FAILED_BATCH_INSERT.getMessage());
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/exception/InvalidApplicantInfoException.java
+++ b/src/main/java/com/yoyomo/domain/application/exception/InvalidApplicantInfoException.java
@@ -1,0 +1,12 @@
+package com.yoyomo.domain.application.exception;
+
+import com.yoyomo.global.config.exception.ApplicationException;
+
+import static com.yoyomo.domain.application.presentation.constant.ResponseMessage.INVALID_APPLICANT_INFO;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class InvalidApplicantInfoException extends ApplicationException {
+    public InvalidApplicantInfoException() {
+        super(BAD_REQUEST.value(), INVALID_APPLICANT_INFO.getMessage());
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/exception/InvalidDateFormat.java
+++ b/src/main/java/com/yoyomo/domain/application/exception/InvalidDateFormat.java
@@ -1,0 +1,12 @@
+package com.yoyomo.domain.application.exception;
+
+import com.yoyomo.global.config.exception.ApplicationException;
+
+import static com.yoyomo.domain.application.presentation.constant.ResponseMessage.INVALID_DATE_FORMAT;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class InvalidDateFormat extends ApplicationException {
+    public InvalidDateFormat() {
+        super(BAD_REQUEST.value(), INVALID_DATE_FORMAT.getMessage());
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/exception/QuestionReplySizeMismatchException.java
+++ b/src/main/java/com/yoyomo/domain/application/exception/QuestionReplySizeMismatchException.java
@@ -1,0 +1,12 @@
+package com.yoyomo.domain.application.exception;
+
+import com.yoyomo.global.config.exception.ApplicationException;
+
+import static com.yoyomo.domain.application.presentation.constant.ResponseMessage.QUESTION_REPLY_SIZE_MISMATCH;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class QuestionReplySizeMismatchException extends ApplicationException {
+    public QuestionReplySizeMismatchException() {
+        super(BAD_REQUEST.value(), QUESTION_REPLY_SIZE_MISMATCH.getMessage());
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/presentation/ApplicationController.java
+++ b/src/main/java/com/yoyomo/domain/application/presentation/ApplicationController.java
@@ -1,5 +1,6 @@
 package com.yoyomo.domain.application.presentation;
 
+import com.yoyomo.domain.application.application.dto.request.ApplicationImportRequest;
 import com.yoyomo.domain.application.application.dto.request.ApplicationMoveRequest;
 import com.yoyomo.domain.application.application.dto.request.ApplicationSaveRequest;
 import com.yoyomo.domain.application.application.dto.request.ApplicationUpdateRequest;
@@ -9,6 +10,7 @@ import com.yoyomo.domain.application.application.dto.response.ApplicantsResponse
 import com.yoyomo.domain.application.application.dto.response.ApplicationDetailResponse;
 import com.yoyomo.domain.application.application.dto.response.ApplicationListResponse;
 import com.yoyomo.domain.application.application.dto.response.MyApplicationResponse;
+import com.yoyomo.domain.application.application.usecase.ApplicationImportUseCase;
 import com.yoyomo.domain.application.application.usecase.ApplicationManageUseCase;
 import com.yoyomo.domain.application.application.usecase.ApplicationVerifyUseCase;
 import com.yoyomo.domain.application.application.usecase.ApplyUseCase;
@@ -58,6 +60,7 @@ public class ApplicationController {
     private final InterviewManageUseCase interviewManageUseCase;
     private final ApplicationManageUseCase applicationManageUseCase;
     private final ApplicationVerifyUseCase applicationVerifyUseCase;
+    private final ApplicationImportUseCase applicationImportUseCase;
 
     // Applicant
     @PostMapping("/{recruitmentId}")
@@ -120,6 +123,18 @@ public class ApplicationController {
 
         return ResponseDto.of(OK.value(), SUCCESS_VERIFY_CODE.getMessage());
     }
+
+    @PostMapping("/{recruitmentId}/import")
+    @Operation(summary = "[Manager] 외부 지원서 응답 가져오기")
+    public ResponseDto<Void> importApplications(@RequestBody ApplicationImportRequest request,
+                                                @PathVariable UUID recruitmentId,
+                                                @CurrentUser User user
+    ) {
+        applicationImportUseCase.importApplications(recruitmentId, user, request);
+
+        return ResponseDto.of(OK.value(), SUCCESS_SAVE.getMessage());
+    }
+
 
     @GetMapping("/manager/{recruitmentId}/all")
     @Operation(summary = "[Manager] 지원서 목록 조회") // todo 로그인 후 Request Body 수정

--- a/src/main/java/com/yoyomo/domain/application/presentation/constant/ResponseMessage.java
+++ b/src/main/java/com/yoyomo/domain/application/presentation/constant/ResponseMessage.java
@@ -41,6 +41,7 @@ public enum ResponseMessage {
     ACCESS_DENIED("권한이 없습니다."),
     ALREADY_APPLIED("이미 지원한 사용자 입니다."),
     FAILED_BATCH_INSERT("지원서 저장에 실패했습니다."),
-    INVALID_APPLICANT_INFO("지원하지 않는 지원자 정보입니다.");
+    INVALID_APPLICANT_INFO("지원하지 않는 지원자 정보입니다."),
+    INVALID_DATE_FORMAT("지원하지 않는 날짜 형식입니다.");
     private final String message;
 }

--- a/src/main/java/com/yoyomo/domain/application/presentation/constant/ResponseMessage.java
+++ b/src/main/java/com/yoyomo/domain/application/presentation/constant/ResponseMessage.java
@@ -39,6 +39,7 @@ public enum ResponseMessage {
     CANNOT_MEMO_UPDATE("메모 수정에 실패했습니다."),
     CANNOT_MEMO_DELETE("메모 삭제에 실패했습니다."),
     ACCESS_DENIED("권한이 없습니다."),
-    ALREADY_APPLIED("이미 지원한 사용자 입니다.");
+    ALREADY_APPLIED("이미 지원한 사용자 입니다."),
+    FAILED_BATCH_INSERT("지원서 저장에 실패했습니다.");
     private final String message;
 }

--- a/src/main/java/com/yoyomo/domain/application/presentation/constant/ResponseMessage.java
+++ b/src/main/java/com/yoyomo/domain/application/presentation/constant/ResponseMessage.java
@@ -40,6 +40,7 @@ public enum ResponseMessage {
     CANNOT_MEMO_DELETE("메모 삭제에 실패했습니다."),
     ACCESS_DENIED("권한이 없습니다."),
     ALREADY_APPLIED("이미 지원한 사용자 입니다."),
-    FAILED_BATCH_INSERT("지원서 저장에 실패했습니다.");
+    FAILED_BATCH_INSERT("지원서 저장에 실패했습니다."),
+    INVALID_APPLICANT_INFO("지원하지 않는 지원자 정보입니다.");
     private final String message;
 }

--- a/src/main/java/com/yoyomo/domain/application/presentation/constant/ResponseMessage.java
+++ b/src/main/java/com/yoyomo/domain/application/presentation/constant/ResponseMessage.java
@@ -42,6 +42,7 @@ public enum ResponseMessage {
     ALREADY_APPLIED("이미 지원한 사용자 입니다."),
     FAILED_BATCH_INSERT("지원서 저장에 실패했습니다."),
     INVALID_APPLICANT_INFO("지원하지 않는 지원자 정보입니다."),
-    INVALID_DATE_FORMAT("지원하지 않는 날짜 형식입니다.");
+    INVALID_DATE_FORMAT("지원하지 않는 날짜 형식입니다."),
+    QUESTION_REPLY_SIZE_MISMATCH("질문과 답변의 개수가 일치하지 않습니다.");
     private final String message;
 }

--- a/src/main/java/com/yoyomo/domain/item/domain/entity/Answer.java
+++ b/src/main/java/com/yoyomo/domain/item/domain/entity/Answer.java
@@ -1,5 +1,6 @@
 package com.yoyomo.domain.item.domain.entity;
 
+import com.yoyomo.domain.item.domain.entity.type.Type;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,4 +13,12 @@ import lombok.experimental.SuperBuilder;
 public class Answer extends Item {
     private String answer;
     private int maxLength;
+
+    public static Item of(String title, String answer) {
+        return Answer.builder()
+                .type(Type.LONG_FORM)
+                .title(title)
+                .answer(answer)
+                .build();
+    }
 }

--- a/src/main/java/com/yoyomo/domain/item/domain/service/factory/AnswerCreationStrategy.java
+++ b/src/main/java/com/yoyomo/domain/item/domain/service/factory/AnswerCreationStrategy.java
@@ -1,5 +1,6 @@
 package com.yoyomo.domain.item.domain.service.factory;
 
+import com.yoyomo.domain.application.domain.model.ApplicantReply;
 import com.yoyomo.domain.item.application.dto.req.ItemRequest;
 import com.yoyomo.domain.item.domain.entity.Answer;
 import com.yoyomo.domain.item.domain.entity.Item;
@@ -7,6 +8,8 @@ import com.yoyomo.domain.item.domain.entity.type.Type;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,5 +31,9 @@ public class AnswerCreationStrategy implements ItemCreationStrategy {
                 .answer(request.answer())
                 .maxLength(request.maxLength())
                 .build();
+    }
+
+    public List<Item> create(ApplicantReply applicantReply) {
+        return applicantReply.toAnswers();
     }
 }

--- a/src/main/java/com/yoyomo/domain/item/domain/service/factory/ItemFactory.java
+++ b/src/main/java/com/yoyomo/domain/item/domain/service/factory/ItemFactory.java
@@ -1,5 +1,6 @@
 package com.yoyomo.domain.item.domain.service.factory;
 
+import com.yoyomo.domain.application.domain.model.ApplicantReply;
 import com.yoyomo.domain.item.application.dto.req.ItemRequest;
 import com.yoyomo.domain.item.domain.entity.Item;
 import com.yoyomo.domain.item.domain.entity.type.Type;
@@ -7,6 +8,7 @@ import com.yoyomo.domain.item.exception.InvalidItemException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Set;
 
 @Component
@@ -14,6 +16,7 @@ import java.util.Set;
 public class ItemFactory {
 
     private final Set<ItemCreationStrategy> creationStrategies;
+    private final AnswerCreationStrategy answerCreationStrategy;
 
     public Item createItem(ItemRequest request) {
         Type type = request.type();
@@ -22,5 +25,9 @@ public class ItemFactory {
                 .findFirst()
                 .orElseThrow(InvalidItemException::new);
         return itemCreationStrategy.create(request);
+    }
+
+    public List<Item> createItem(ApplicantReply applicantReplies) {
+        return answerCreationStrategy.create(applicantReplies);
     }
 }

--- a/src/main/java/com/yoyomo/domain/recruitment/domain/repository/RecruitmentRepository.java
+++ b/src/main/java/com/yoyomo/domain/recruitment/domain/repository/RecruitmentRepository.java
@@ -35,6 +35,10 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, UUID> 
     void increaseApplicantCount(UUID recruitmentId);
 
     @Modifying
+    @Query("UPDATE Recruitment r SET r.totalApplicantsCount = r.totalApplicantsCount + :count WHERE r.id = :recruitmentId")
+    void increaseApplicantCount(UUID recruitmentId, int count);
+
+    @Modifying
     @Query("UPDATE Recruitment r SET r.totalApplicantsCount = r.totalApplicantsCount - 1 WHERE r.id = :recruitmentId")
     void decreaseApplicantCount(UUID recruitmentId);
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,7 +16,7 @@ spring:
     kakao-redirect-uri: ${KAKAO_REDIRECT_URL}
   data:
     mongodb:
-      uri: mongodb://${USERNAME}:${PASSWORD}@${HOST:localhost}:${PORT:27017}/${DATABASE:crayon}
+      uri: mongodb://${HOST:localhost}:${PORT:27017}/${DATABASE:crayon}
       host: ${HOST:localhost}
       port: ${PORT:27017}
       database: ${DATABASE:crayon}

--- a/src/test/java/com/yoyomo/domain/application/application/usecase/ApplicationImportUseCaseTest.java
+++ b/src/test/java/com/yoyomo/domain/application/application/usecase/ApplicationImportUseCaseTest.java
@@ -13,17 +13,19 @@ import com.yoyomo.domain.club.domain.entity.Club;
 import com.yoyomo.domain.club.domain.repository.ClubMangerRepository;
 import com.yoyomo.domain.club.domain.repository.ClubRepository;
 import com.yoyomo.domain.fixture.TestFixture;
+import com.yoyomo.domain.recruitment.domain.entity.Process;
 import com.yoyomo.domain.recruitment.domain.entity.Recruitment;
+import com.yoyomo.domain.recruitment.domain.repository.ProcessRepository;
 import com.yoyomo.domain.recruitment.domain.repository.RecruitmentRepository;
 import com.yoyomo.domain.user.domain.entity.User;
 import com.yoyomo.domain.user.domain.repository.UserRepository;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class ApplicationImportUseCaseTest extends ApplicationTest {
 
@@ -38,6 +40,9 @@ class ApplicationImportUseCaseTest extends ApplicationTest {
 
     @Autowired
     RecruitmentRepository recruitmentRepository;
+
+    @Autowired
+    ProcessRepository processRepository;
 
     @Autowired
     ApplicationRepository applicationRepository;
@@ -55,7 +60,10 @@ class ApplicationImportUseCaseTest extends ApplicationTest {
         Club club = clubRepository.save(TestFixture.club());
         clubMangerRepository.save(TestFixture.clubManager(club, user));
 
-        Recruitment recruitment = recruitmentRepository.save(TestFixture.recruitment(club));
+        Process process = processRepository.save(TestFixture.process(1));
+        Recruitment recruitment = recruitmentRepository.save(TestFixture.recruitment(club, process));
+        process.addRecruitment(recruitment);
+        processRepository.save(process);
 
         List<QuestionRequest> questionRequests = List.of(
                 new QuestionRequest("이름을 적어", "string"),
@@ -99,7 +107,7 @@ class ApplicationImportUseCaseTest extends ApplicationTest {
                 );
 
         List<Application> applications = applicationRepository.findAll();
-        Assertions.assertAll(
+        assertAll(
                 () -> assertThat(applications).hasSize(2),
                 () -> assertThat(applications.get(0).getUserName()).isEqualTo("나아연"),
                 () -> assertThat(applications.get(0).getTel()).isEqualTo("01012345678"),
@@ -107,7 +115,7 @@ class ApplicationImportUseCaseTest extends ApplicationTest {
         );
 
         List<Answer> answers = answerRepository.findAll();
-        Assertions.assertAll(
+        assertAll(
                 () -> assertThat(answers).hasSize(2),
                 () -> assertThat(answers.get(0).getApplicationId()).isNotNull(),
                 () -> assertThat(answers.get(0).getItems()).hasSize(3)

--- a/src/test/java/com/yoyomo/domain/application/application/usecase/ApplicationImportUseCaseTest.java
+++ b/src/test/java/com/yoyomo/domain/application/application/usecase/ApplicationImportUseCaseTest.java
@@ -1,0 +1,116 @@
+package com.yoyomo.domain.application.application.usecase;
+
+import com.yoyomo.domain.ApplicationTest;
+import com.yoyomo.domain.application.application.dto.request.ApplicationImportRequest;
+import com.yoyomo.domain.application.application.dto.request.DataRequest;
+import com.yoyomo.domain.application.application.dto.request.QuestionRequest;
+import com.yoyomo.domain.application.application.dto.request.RespondentRequest;
+import com.yoyomo.domain.application.domain.entity.Answer;
+import com.yoyomo.domain.application.domain.entity.Application;
+import com.yoyomo.domain.application.domain.repository.ApplicationRepository;
+import com.yoyomo.domain.application.domain.repository.mongo.AnswerRepository;
+import com.yoyomo.domain.club.domain.entity.Club;
+import com.yoyomo.domain.club.domain.repository.ClubMangerRepository;
+import com.yoyomo.domain.club.domain.repository.ClubRepository;
+import com.yoyomo.domain.fixture.TestFixture;
+import com.yoyomo.domain.recruitment.domain.entity.Recruitment;
+import com.yoyomo.domain.recruitment.domain.repository.RecruitmentRepository;
+import com.yoyomo.domain.user.domain.entity.User;
+import com.yoyomo.domain.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApplicationImportUseCaseTest extends ApplicationTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    ClubMangerRepository clubMangerRepository;
+
+    @Autowired
+    ClubRepository clubRepository;
+
+    @Autowired
+    RecruitmentRepository recruitmentRepository;
+
+    @Autowired
+    ApplicationRepository applicationRepository;
+
+    @Autowired
+    AnswerRepository answerRepository;
+
+    @Autowired
+    ApplicationImportUseCase applicationImportUseCase;
+
+    @Test
+    void importApplications() {
+        // given
+        User user = userRepository.save(TestFixture.user());
+        Club club = clubRepository.save(TestFixture.club());
+        clubMangerRepository.save(TestFixture.clubManager(club, user));
+
+        Recruitment recruitment = recruitmentRepository.save(TestFixture.recruitment(club));
+
+        List<QuestionRequest> questionRequests = List.of(
+                new QuestionRequest("이름을 적어", "string"),
+                new QuestionRequest("입력해라 전화번호", "string"),
+                new QuestionRequest("언제볼래", "datetime"),
+                new QuestionRequest("배고프세요?", "string"),
+                new QuestionRequest("졸리세요?", "string")
+        );
+
+        List<RespondentRequest> respondentRequests = List.of(
+                new RespondentRequest(
+                        List.of(
+                                new DataRequest("나아연"),
+                                new DataRequest("01012345678"),
+                                new DataRequest("Date(2025,05,30,19,36,00"),
+                                new DataRequest("죽겠어요"),
+                                new DataRequest(null)
+                        )
+                ),
+                new RespondentRequest(
+                        List.of(
+                                new DataRequest("이근표"),
+                                new DataRequest("01087654321"),
+                                new DataRequest("Date(2025,05,30,19,36,00"),
+                                new DataRequest(null),
+                                new DataRequest("기절")
+                        )
+                )
+        );
+
+        ApplicationImportRequest applicationImportRequest = new ApplicationImportRequest(questionRequests, respondentRequests);
+
+        // when
+        applicationImportUseCase.importApplications(recruitment.getId(), user, applicationImportRequest);
+
+        // then
+        assertThat(recruitmentRepository.findById(recruitment.getId()))
+                .isPresent()
+                .hasValueSatisfying(result ->
+                        assertThat(result.getTotalApplicantsCount()).isEqualTo(2)
+                );
+
+        List<Application> applications = applicationRepository.findAll();
+        Assertions.assertAll(
+                () -> assertThat(applications).hasSize(2),
+                () -> assertThat(applications.get(0).getUserName()).isEqualTo("나아연"),
+                () -> assertThat(applications.get(0).getTel()).isEqualTo("01012345678"),
+                () -> assertThat(applications.get(0).getEmail()).isEmpty()
+        );
+
+        List<Answer> answers = answerRepository.findAll();
+        Assertions.assertAll(
+                () -> assertThat(answers).hasSize(2),
+                () -> assertThat(answers.get(0).getApplicationId()).isNotNull(),
+                () -> assertThat(answers.get(0).getItems()).hasSize(3)
+        );
+    }
+}

--- a/src/test/java/com/yoyomo/domain/application/application/usecase/ApplicationImportUseCaseTest.java
+++ b/src/test/java/com/yoyomo/domain/application/application/usecase/ApplicationImportUseCaseTest.java
@@ -70,7 +70,7 @@ class ApplicationImportUseCaseTest extends ApplicationTest {
                         List.of(
                                 new DataRequest("나아연"),
                                 new DataRequest("01012345678"),
-                                new DataRequest("Date(2025,05,30,19,36,00"),
+                                new DataRequest("Date(2025,05,30,19,36,00)"),
                                 new DataRequest("죽겠어요"),
                                 new DataRequest(null)
                         )
@@ -79,7 +79,7 @@ class ApplicationImportUseCaseTest extends ApplicationTest {
                         List.of(
                                 new DataRequest("이근표"),
                                 new DataRequest("01087654321"),
-                                new DataRequest("Date(2025,05,30,19,36,00"),
+                                new DataRequest("Date(2025,05,30,19,36,00)"),
                                 new DataRequest(null),
                                 new DataRequest("기절")
                         )

--- a/src/test/java/com/yoyomo/domain/fixture/CustomRepository.java
+++ b/src/test/java/com/yoyomo/domain/fixture/CustomRepository.java
@@ -19,6 +19,7 @@ public class CustomRepository {
     public void clearAndReset() {
         entityManager.createNativeQuery("DELETE FROM application").executeUpdate();
         entityManager.createNativeQuery("DELETE FROM interview_record").executeUpdate();
+        entityManager.createNativeQuery("DELETE FROM process").executeUpdate();
         entityManager.createNativeQuery("DELETE FROM recruitment").executeUpdate();
         entityManager.createNativeQuery("DELETE FROM club_manager").executeUpdate();
         entityManager.createNativeQuery("DELETE FROM club").executeUpdate();

--- a/src/test/java/com/yoyomo/domain/fixture/CustomRepository.java
+++ b/src/test/java/com/yoyomo/domain/fixture/CustomRepository.java
@@ -3,6 +3,7 @@ package com.yoyomo.domain.fixture;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -10,6 +11,9 @@ public class CustomRepository {
 
     @Autowired
     private EntityManager entityManager;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
 
     @Transactional
     public void clearAndReset() {
@@ -19,6 +23,9 @@ public class CustomRepository {
         entityManager.createNativeQuery("DELETE FROM club_manager").executeUpdate();
         entityManager.createNativeQuery("DELETE FROM club").executeUpdate();
         entityManager.createNativeQuery("DELETE FROM user").executeUpdate();
+
+        mongoTemplate.dropCollection("answers");
+        mongoTemplate.dropCollection("forms");
 
         entityManager.createNativeQuery("ALTER TABLE user ALTER COLUMN user_id RESTART WITH 1").executeUpdate();
     }

--- a/src/test/java/com/yoyomo/domain/fixture/TestFixture.java
+++ b/src/test/java/com/yoyomo/domain/fixture/TestFixture.java
@@ -16,6 +16,7 @@ import com.yoyomo.domain.user.domain.entity.User;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.UUID;
 
 public class TestFixture {
@@ -59,6 +60,18 @@ public class TestFixture {
                 .build();
     }
 
+    public static Recruitment recruitment(Club club, Process... processes) {
+        return Recruitment.builder()
+                .title("모집")
+                .isActive(false)
+                .startAt(LocalDateTime.now().minusHours(1))
+                .endAt(LocalDateTime.now().plusDays(1))
+                .currentProcess(Type.FORM)
+                .club(club)
+                .processes(Arrays.stream(processes).toList())
+                .build();
+    }
+
     public static Application application(User user) {
         return Application.builder()
                 .user(user)
@@ -76,6 +89,12 @@ public class TestFixture {
 
     public static Process process() {
         return Process.builder()
+                .build();
+    }
+
+    public static Process process(int stage) {
+        return Process.builder()
+                .stage(stage)
                 .build();
     }
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -12,7 +12,7 @@ spring.jpa.show-sql=true
 spring.application.kakao-client-id=secret
 spring.application.kakao-redirect-uri=secret
 # spring.data.mongodb.*
-spring.data.mongodb.uri=mongodb://admin:admin@localhost:27017/crayon-test?authSource=admin
+spring.data.mongodb.uri=mongodb://localhost:27017/crayon-test
 spring.data.mongodb.host=${HOST:localhost}
 spring.data.mongodb.port=${PORT:27017}
 spring.data.mongodb.database=${DATABASE:crayon-test}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -12,11 +12,10 @@ spring.jpa.show-sql=true
 spring.application.kakao-client-id=secret
 spring.application.kakao-redirect-uri=secret
 # spring.data.mongodb.*
-spring.data.mongodb.uri=mongodb://${HOST:localhost}:${PORT:27017}/${DATABASE:crayon}
+spring.data.mongodb.uri=mongodb://admin:admin@localhost:27017/crayon-test?authSource=admin
 spring.data.mongodb.host=${HOST:localhost}
 spring.data.mongodb.port=${PORT:27017}
-spring.data.mongodb.database=${DATABASE:crayon}
-spring.data.mongodb.authentication-database=admin
+spring.data.mongodb.database=${DATABASE:crayon-test}
 spring.data.mongodb.uuid-representation=standard
 # spring.data.redis.*
 spring.data.redis.host=localhost


### PR DESCRIPTION
## 🚀 PR 요약
외부 지원서를 가져오는 기능을 만들었어요

## ✨ PR 상세 내용
기존 Application, Item 이랑 모양이 상이하다보니 service에서 파싱하는 게 너무 많아졌어요
그래서 model 계층을 도입해서 객체끼리 지지고볶도록 (노력)했어요

용어 설명 드리겠습니다.
- Applicant : Application(Entity)의 username, tel, email 과 매핑될 정보
- ApplicantInfo: username, tel, email과 매핑하기 위한 폼 문항(col)
- Question: 지원서 문항(질문, 타입(날짜, 글자. .. ))
- Reply: 답변
- Replies: 답변들
- QuestionReply: 문항, 답변
- ApplicantReply: Applicant(username, tel, email)를 포함한 지원서 문항 & 답변 (List<QuestionReply>)


## 🚨 주의 사항
mongoDB를 테스트에 넣었더니 돌아가려나요

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 외부 지원서 응답을 일괄로 가져와 등록하는 기능이 추가되었습니다. 관리자는 지원자 정보와 답변을 한 번에 업로드할 수 있습니다.
  - 지원서 및 답변 일괄 저장 기능이 도입되어 대량 데이터 처리 효율이 향상되었습니다.
  - 지원서 데이터 변환 및 처리 관련 도메인 모델과 서비스가 새롭게 추가되었습니다.

- **버그 수정**
  - 테스트 환경에서 MongoDB 컬렉션 초기화 및 연결 설정이 개선되었습니다.

- **문서화**
  - 신규 API 엔드포인트 및 데이터 구조에 대한 설명이 추가되었습니다.

- **테스트**
  - 지원서 일괄 가져오기 기능에 대한 통합 테스트가 추가되었습니다.

- **환경설정/작업**
  - CI 환경에 MongoDB 6.0 서비스가 추가되어 빌드 및 테스트 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->