### PR TITLE
DataType 추가 및 테스트 작성

### DIFF
--- a/src/main/java/com/yoyomo/domain/application/application/dto/request/ApplicationImportRequest.java
+++ b/src/main/java/com/yoyomo/domain/application/application/dto/request/ApplicationImportRequest.java
@@ -32,7 +32,7 @@ public record ApplicationImportRequest(
 
     private List<Replies> toReplies() {
         return rows.stream()
-                .map(RespondentRequest::toAnswers)
+                .map(RespondentRequest::toReplies)
                 .toList();
     }
 

--- a/src/main/java/com/yoyomo/domain/application/application/dto/request/DataRequest.java
+++ b/src/main/java/com/yoyomo/domain/application/application/dto/request/DataRequest.java
@@ -6,7 +6,7 @@ public record DataRequest(
         String v
 ) {
 
-    public Reply toAnswer() {
+    public Reply toReply() {
         return new Reply(v);
     }
 }

--- a/src/main/java/com/yoyomo/domain/application/application/dto/request/RespondentRequest.java
+++ b/src/main/java/com/yoyomo/domain/application/application/dto/request/RespondentRequest.java
@@ -9,9 +9,9 @@ public record RespondentRequest(
         List<DataRequest> c
 ) {
 
-    public Replies toAnswers() {
+    public Replies toReplies() {
         List<Reply> replies = c.stream()
-                .map(DataRequest::toAnswer)
+                .map(DataRequest::toReply)
                 .toList();
         return new Replies(replies);
     }

--- a/src/main/java/com/yoyomo/domain/application/domain/vo/DataType.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/vo/DataType.java
@@ -10,15 +10,15 @@ import java.util.function.Function;
 @AllArgsConstructor
 public enum DataType {
 
-    BOOLEAN("boolean", Reply::new),
-    NUMBER("number", Reply::new),
-    STRING("string", Reply::new),
-    DATE("date", input -> new Reply(DateFormatter.format(input))),
-    DATE_TIME("datetime", input -> new Reply(DateFormatter.format(input))),
-    TIME_OF_DATE("timeofday", input -> new Reply(DateFormatter.format(input)));
+    BOOLEAN("boolean", Function.identity()),
+    NUMBER("number", Function.identity()),
+    STRING("string", Function.identity()),
+    DATE("date", DateFormatter::format),
+    DATE_TIME("datetime", DateFormatter::format),
+    TIME_OF_DATE("timeofday", DateFormatter::format);
 
     private final String type;
-    private final Function<String, Reply> function;
+    private final Function<String, String> function;
 
     public static DataType match(String type) {
         return Arrays.stream(values())
@@ -27,7 +27,7 @@ public enum DataType {
                 .orElseThrow(InvalidDataType::new);
     }
 
-    public Reply format(String input) {
+    public String format(String input) {
         return function.apply(input);
     }
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/vo/DataType.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/vo/DataType.java
@@ -1,0 +1,33 @@
+package com.yoyomo.domain.application.domain.vo;
+
+import com.yoyomo.domain.application.exception.InvalidDataType;
+import com.yoyomo.global.common.util.DateFormatter;
+import lombok.AllArgsConstructor;
+
+import java.util.Arrays;
+import java.util.function.Function;
+
+@AllArgsConstructor
+public enum DataType {
+
+    BOOLEAN("boolean", Reply::new),
+    NUMBER("number", Reply::new),
+    STRING("string", Reply::new),
+    DATE("date", input -> new Reply(DateFormatter.format(input))),
+    DATE_TIME("datetime", input -> new Reply(DateFormatter.format(input))),
+    TIME_OF_DATE("timeofday", input -> new Reply(DateFormatter.format(input)));
+
+    private final String type;
+    private final Function<String, Reply> function;
+
+    public static DataType match(String type) {
+        return Arrays.stream(values())
+                .filter(v -> v.type.equals(type.toLowerCase()))
+                .findFirst()
+                .orElseThrow(InvalidDataType::new);
+    }
+
+    public Reply format(String input) {
+        return function.apply(input);
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/domain/vo/Question.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/vo/Question.java
@@ -22,6 +22,10 @@ public class Question {
         return this.title.contains(keyword);
     }
 
+    public DataType matchDataType() {
+        return DataType.match(type);
+    }
+
     public String getTitle() {
         return title;
     }

--- a/src/main/java/com/yoyomo/domain/application/domain/vo/Question.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/vo/Question.java
@@ -10,10 +10,6 @@ public class Question {
     private final String title;
     private final String type;
 
-    public boolean isDateType() {
-        return "datetime".equals(type);
-    }
-
     public boolean isApplicantInfo() {
         return ApplicantInfo.anyMatch(title);
     }

--- a/src/main/java/com/yoyomo/domain/application/domain/vo/QuestionReply.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/vo/QuestionReply.java
@@ -13,10 +13,12 @@ public class QuestionReply {
     private final Reply reply;
 
     public static QuestionReply of(Question question, Reply reply) {
-        if (!reply.isEmpty() && question.isDateType()) {
-            return new QuestionReply(question, reply.formatDate());
+        if (!reply.isEmpty()) {
+            return new QuestionReply(question, reply);
         }
-        return new QuestionReply(question, reply);
+
+        DataType dataType = question.matchDataType();
+        return new QuestionReply(question, reply.format(dataType));
     }
 
     public QuestionCategory getCategory() {

--- a/src/main/java/com/yoyomo/domain/application/domain/vo/Reply.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/vo/Reply.java
@@ -22,6 +22,7 @@ public class Reply {
     }
 
     public Reply format(DataType dataType) {
-        return dataType.format(value);
+        String formatted = dataType.format(value);
+        return new Reply(formatted);
     }
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/vo/Reply.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/vo/Reply.java
@@ -1,15 +1,11 @@
 package com.yoyomo.domain.application.domain.vo;
 
-import com.yoyomo.domain.application.exception.InvalidDateFormat;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode
 @AllArgsConstructor
 public class Reply {
-
-    private static final String DATE_FORMAT = "%s-%s-%s";
-    private static final String DATE_TIME_FORMAT = "%s-%s-%s %s:%s";
 
     private final String value;
 
@@ -21,20 +17,11 @@ public class Reply {
         return value == null || value.isEmpty();
     }
 
-    public Reply formatDate() {
-        String[] split = value.split(",");
-        if (split.length >= 5) {
-            String formatted = String.format(DATE_TIME_FORMAT, split[0], split[1], split[2], split[3], split[4]);
-            return new Reply(formatted);
-        }
-        if (split.length >= 3) {
-            String formatted = String.format(DATE_FORMAT, split[0], split[1], split[2]);
-            return new Reply(formatted);
-        }
-        throw new InvalidDateFormat();
-    }
-
     public String value() {
         return value;
+    }
+
+    public Reply format(DataType dataType) {
+        return dataType.format(value);
     }
 }

--- a/src/main/java/com/yoyomo/domain/application/exception/InvalidDataType.java
+++ b/src/main/java/com/yoyomo/domain/application/exception/InvalidDataType.java
@@ -1,0 +1,12 @@
+package com.yoyomo.domain.application.exception;
+
+import com.yoyomo.global.config.exception.ApplicationException;
+
+import static com.yoyomo.domain.application.presentation.constant.ResponseMessage.INVALID_DATA_TYPE;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class InvalidDataType extends ApplicationException {
+    public InvalidDataType() {
+        super(BAD_REQUEST.value(), INVALID_DATA_TYPE.getMessage());
+    }
+}

--- a/src/main/java/com/yoyomo/domain/application/presentation/constant/ResponseMessage.java
+++ b/src/main/java/com/yoyomo/domain/application/presentation/constant/ResponseMessage.java
@@ -43,7 +43,7 @@ public enum ResponseMessage {
     FAILED_BATCH_INSERT("지원서 저장에 실패했습니다."),
     INVALID_APPLICANT_INFO("지원하지 않는 지원자 정보입니다."),
     INVALID_DATE_FORMAT("지원하지 않는 날짜 형식입니다."),
-    INVALID_DATA_TYPE("지원하지 않는 날짜 형식입니다."),
+    INVALID_DATA_TYPE("지원하지 않는 데이터 타입입니다."),
     QUESTION_REPLY_SIZE_MISMATCH("질문과 답변의 개수가 일치하지 않습니다."),
     APPLICATION_REPLY_SIZE_MISMATCH("지원서와 답변의 개수가 일치하지 않습니다.");
     private final String message;

--- a/src/main/java/com/yoyomo/domain/application/presentation/constant/ResponseMessage.java
+++ b/src/main/java/com/yoyomo/domain/application/presentation/constant/ResponseMessage.java
@@ -43,6 +43,7 @@ public enum ResponseMessage {
     FAILED_BATCH_INSERT("지원서 저장에 실패했습니다."),
     INVALID_APPLICANT_INFO("지원하지 않는 지원자 정보입니다."),
     INVALID_DATE_FORMAT("지원하지 않는 날짜 형식입니다."),
+    INVALID_DATA_TYPE("지원하지 않는 날짜 형식입니다."),
     QUESTION_REPLY_SIZE_MISMATCH("질문과 답변의 개수가 일치하지 않습니다."),
     APPLICATION_REPLY_SIZE_MISMATCH("지원서와 답변의 개수가 일치하지 않습니다.");
     private final String message;

--- a/src/main/java/com/yoyomo/global/common/util/DateFormatter.java
+++ b/src/main/java/com/yoyomo/global/common/util/DateFormatter.java
@@ -1,12 +1,27 @@
 package com.yoyomo.global.common.util;
 
+import com.yoyomo.domain.application.exception.InvalidDateFormat;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class DateFormatter {
 
     private static final String MAIL_DATE_FORMAT = "M월 d일(E) HH:mm";
+    private static final List<FormatterEntry> ENTRIES = List.of(
+            new FormatterEntry(
+                    Pattern.compile("^Date\\((\\d+),(\\d+),(\\d+),(\\d+),(\\d+),(\\d+)\\)$"),
+                    "%04d-%02d-%02d %02d:%02d"
+            ),
+            new FormatterEntry(
+                    Pattern.compile("^Date\\((\\d+),(\\d+),(\\d+)\\)$"),
+                    "%04d-%02d-%02d"
+            )
+    );
 
     private DateFormatter() {
     }
@@ -15,5 +30,39 @@ public class DateFormatter {
         LocalDateTime dateTime = LocalDateTime.parse(date);
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(MAIL_DATE_FORMAT, Locale.KOREAN);
         return dateTime.format(formatter);
+    }
+
+    public static String format(String dateTime) {
+        if (dateTime == null || dateTime.isBlank()) {
+            return null;
+        }
+
+        String trimmed = dateTime.trim();
+        for (FormatterEntry entry : ENTRIES) {
+            Matcher m = entry.pattern.matcher(trimmed);
+            if (m.matches()) {
+                return format(entry, m);
+            }
+        }
+        throw new InvalidDateFormat();
+    }
+
+    private static String format(FormatterEntry entry, Matcher m) {
+        int groupCount = m.groupCount();
+        Object[] args = new Object[groupCount];
+        for (int i = 1; i <= groupCount; i++) {
+            args[i - 1] = Integer.parseInt(m.group(i));
+        }
+        return String.format(entry.format, args);
+    }
+
+    private static class FormatterEntry {
+        private final Pattern pattern;
+        private final String format;
+
+        FormatterEntry(Pattern pattern, String format) {
+            this.pattern = pattern;
+            this.format = format;
+        }
     }
 }

--- a/src/test/java/com/yoyomo/domain/application/domain/vo/ApplicationReplyTest.java
+++ b/src/test/java/com/yoyomo/domain/application/domain/vo/ApplicationReplyTest.java
@@ -1,0 +1,38 @@
+package com.yoyomo.domain.application.domain.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class ApplicationReplyTest {
+
+    @DisplayName("지원자 정보(이름, 전화번호, 이메일)와 일반 질문 답변으로 분리한다.")
+    @Test
+    void of() {
+        // given
+        List<QuestionReply> questionReplies = List.of(
+                new QuestionReply(new Question("이름이 뭐에요", "string"), new Reply("나아연")),
+                new QuestionReply(new Question("전화번호 뭐에요", "string"), new Reply("01099998888")),
+                new QuestionReply(new Question("꿈이 뭐에요", "string"), new Reply("백만장자")),
+                new QuestionReply(new Question("생일?", "datetime"), new Reply("Date(2001,3,22)"))
+        );
+
+        // when
+        ApplicationReply applicationReply = ApplicationReply.of(questionReplies);
+
+        // then
+        Applicant applicant = applicationReply.getApplicant();
+        assertThat(applicant).isNotNull();
+        assertAll(
+                () -> assertThat(applicant.getName()).isEqualTo("나아연"),
+                () -> assertThat(applicant.getPhone()).isEqualTo("01099998888"),
+                () -> assertThat(applicant.getEmail()).isEmpty()
+        );
+
+        assertThat(applicationReply.getFormQuestionReplies()).hasSize(2);
+    }
+}

--- a/src/test/java/com/yoyomo/domain/application/domain/vo/DataTypeTest.java
+++ b/src/test/java/com/yoyomo/domain/application/domain/vo/DataTypeTest.java
@@ -1,10 +1,12 @@
 package com.yoyomo.domain.application.domain.vo;
 
+import com.yoyomo.domain.application.exception.InvalidDataType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class DataTypeTest {
 
@@ -17,5 +19,24 @@ class DataTypeTest {
 
         // then
         assertThat(match).isEqualTo(DataType.DATE_TIME);
+    }
+
+    @DisplayName("데이터 타입을 올바르게 매칭한다")
+    @CsvSource(value = {"date,DATE", "string,STRING"})
+    @ParameterizedTest
+    void matchOtherDataTypes(String input, DataType expected) {
+        // when
+        DataType dataType = DataType.match(input);
+
+        // then
+        assertThat(dataType).isEqualTo(expected);
+    }
+
+    @DisplayName("지원하지 않는 데이터 타입에 대해 예외를 발생시킨다")
+    @CsvSource(value = {"invalid"})
+    @ParameterizedTest
+    void matchInvalidDataType(String invalidDataType) {
+        assertThatThrownBy(() -> DataType.match(invalidDataType))
+                .isInstanceOf(InvalidDataType.class);
     }
 }

--- a/src/test/java/com/yoyomo/domain/application/domain/vo/DataTypeTest.java
+++ b/src/test/java/com/yoyomo/domain/application/domain/vo/DataTypeTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class DataTypeTest {
 
     @DisplayName("데이터 타입을 찾는다")
-    @CsvSource(value = {"dateTime", "dateTime", "Datetime", "DateTime"})
+    @CsvSource(value = {"dateTime", "dateTime", "Datetime", "DATETIME"})
     @ParameterizedTest
     void match(String data) {
         // when

--- a/src/test/java/com/yoyomo/domain/application/domain/vo/DataTypeTest.java
+++ b/src/test/java/com/yoyomo/domain/application/domain/vo/DataTypeTest.java
@@ -1,0 +1,21 @@
+package com.yoyomo.domain.application.domain.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DataTypeTest {
+
+    @DisplayName("데이터 타입을 찾는다")
+    @CsvSource(value = {"dateTime", "dateTime", "Datetime", "DateTime"})
+    @ParameterizedTest
+    void match(String data) {
+        // when
+        DataType match = DataType.match(data);
+
+        // then
+        assertThat(match).isEqualTo(DataType.DATE_TIME);
+    }
+}

--- a/src/test/java/com/yoyomo/domain/application/domain/vo/ReplyTest.java
+++ b/src/test/java/com/yoyomo/domain/application/domain/vo/ReplyTest.java
@@ -1,0 +1,35 @@
+package com.yoyomo.domain.application.domain.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReplyTest {
+
+    @DisplayName("날짜와 시간을 포맷팅한다.")
+    @Test
+    void format_datetime() {
+        // given
+        Reply dateReply = new Reply("Date(2025,6,4,15,0,0)");
+
+        // when
+        Reply reply = dateReply.format(DataType.DATE_TIME);
+
+        // then
+        assertThat(reply.value()).isEqualTo("2025-06-04 15:00");
+    }
+
+    @DisplayName("날짜를 포맷팅한다.")
+    @Test
+    void formatDate() {
+        // given
+        Reply dateReply = new Reply("Date(2025,6,4)");
+
+        // when
+        Reply reply = dateReply.format(DataType.DATE);
+
+        // then
+        assertThat(reply.value()).isEqualTo("2025-06-04");
+    }
+}


### PR DESCRIPTION
## 🚀 PR 요약
- DataType(date, datetime, string ...)을 추가했습니다
- 테스트를 작성했습니다

## ✨ PR 상세 내용
- 구글시트에서 받아오는 데이터는 아래와 같습니다. 해당 `type`에 맞춘 `DataType`을 추가했습니다.
  - Answer에서 모두 String으로 받고 있기 때문에 boolean, string, number를 적합한 타입으로 변경하지 않고 String 을 유지했습니다.
  - 구글 시트를 직접 확인해보니 시간이 공식문서와 다르게 `Date(0000,00,00)` 처럼 들어오길래 일단 그렇게 파싱했습니다.

<img width="967" alt="image" src="https://github.com/user-attachments/assets/e02f1059-d3c0-4b5d-825f-21bb52462c1b" />


## 🚨 주의 사항
timeofdate 구글 시트에서 json으로 파싱되는 값 확인 필요

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 다양한 데이터 타입(BOOLEAN, NUMBER, STRING, DATE, DATE_TIME, TIME_OF_DATE)을 지원하는 데이터 타입 구분 기능이 추가되었습니다.
  - 잘못된 데이터 타입 입력 시 명확한 오류 메시지와 예외 처리가 제공됩니다.
  - 날짜 및 날짜-시간 문자열 포맷팅 기능이 향상되어 다양한 형식의 날짜 데이터를 일관되게 처리합니다.
  - 답변 데이터의 포맷팅 로직이 개선되어 데이터 타입에 따른 일관된 처리와 확장성을 확보했습니다.
  - 답변 및 응답 관련 메서드 명칭이 일관성 있게 변경되었습니다.

- **버그 수정**
  - 날짜 및 날짜-시간 형식의 입력값이 보다 일관된 포맷으로 변환되어 표시됩니다.

- **테스트**
  - 데이터 타입 매칭, 답변 포맷팅, 지원자 정보 분리 등 신규 기능에 대한 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->