### PR TITLE
CRA-165 모집 삭제시 평가가 있을 경우 제약조건으로 삭제가 되지 않는 현상 수정

### DIFF
--- a/src/main/java/com/yoyomo/domain/application/domain/repository/EvaluationMemoRepository.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/repository/EvaluationMemoRepository.java
@@ -1,23 +1,31 @@
 package com.yoyomo.domain.application.domain.repository;
 
-import com.yoyomo.domain.application.domain.entity.Application;
-import com.yoyomo.domain.application.domain.entity.EvaluationMemo;
-import com.yoyomo.domain.user.domain.entity.User;
+import java.util.List;
+import java.util.UUID;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
+import com.yoyomo.domain.application.domain.entity.Application;
+import com.yoyomo.domain.application.domain.entity.EvaluationMemo;
+import com.yoyomo.domain.user.domain.entity.User;
+
+import io.lettuce.core.dynamic.annotation.Param;
 
 public interface EvaluationMemoRepository extends JpaRepository<EvaluationMemo, Long> {
 
-    List<EvaluationMemo> findAllByApplication(Application application);
+	List<EvaluationMemo> findAllByApplication(Application application);
 
-    @Modifying
-    @Query("DELETE FROM EvaluationMemo em WHERE em.id = :memoId AND em.manager = :manager")
-    int deleteByIdAndManager(long memoId, User manager);
+	@Modifying
+	@Query("DELETE FROM EvaluationMemo em WHERE em.id = :memoId AND em.manager = :manager")
+	int deleteByIdAndManager(long memoId, User manager);
 
-    @Modifying
-    @Query("UPDATE EvaluationMemo em SET em.memo = :memo WHERE em.id = :memoId AND em.manager = :manager")
-    int updateByIdAndManager(String memo, long memoId, User manager);
+	@Modifying
+	@Query("UPDATE EvaluationMemo em SET em.memo = :memo WHERE em.id = :memoId AND em.manager = :manager")
+	int updateByIdAndManager(String memo, long memoId, User manager);
+
+	@Modifying
+	@Query("DELETE FROM EvaluationMemo em WHERE em.application.recruitmentId = :recruitmentId")
+	void deleteByRecruitmentId(@Param("recruitmentId") UUID recruitmentId);
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/repository/EvaluationRepository.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/repository/EvaluationRepository.java
@@ -1,20 +1,29 @@
 package com.yoyomo.domain.application.domain.repository;
 
-import com.yoyomo.domain.application.domain.entity.Application;
-import com.yoyomo.domain.application.domain.entity.Evaluation;
-import com.yoyomo.domain.user.domain.entity.User;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import com.yoyomo.domain.application.domain.entity.Application;
+import com.yoyomo.domain.application.domain.entity.Evaluation;
+import com.yoyomo.domain.user.domain.entity.User;
+
+import io.lettuce.core.dynamic.annotation.Param;
+
 public interface EvaluationRepository extends JpaRepository<Evaluation, Long> {
 
-    List<Evaluation> findAllByApplicationId(UUID applicationId);
+	List<Evaluation> findAllByApplicationId(UUID applicationId);
 
-    @EntityGraph(attributePaths = "manager")
-    List<Evaluation> findAllByApplication(Application application);
+	@EntityGraph(attributePaths = "manager")
+	List<Evaluation> findAllByApplication(Application application);
 
-    boolean existsByManagerAndApplication(User manager, Application application);
+	boolean existsByManagerAndApplication(User manager, Application application);
+
+	@Modifying
+	@Query("DELETE FROM Evaluation e WHERE e.application.recruitmentId = :recruitmentId")
+	void deleteByRecruitmentId(@Param("recruitmentId") UUID recruitmentId);
 }

--- a/src/main/java/com/yoyomo/domain/application/domain/service/EvaluationDeleteService.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/service/EvaluationDeleteService.java
@@ -1,0 +1,21 @@
+package com.yoyomo.domain.application.domain.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.yoyomo.domain.application.domain.repository.EvaluationRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EvaluationDeleteService {
+	private final EvaluationRepository evaluationRepository;
+
+	public void deleteEvaluationByRecruitmentId(UUID recruitmentId) {
+		evaluationRepository.deleteByRecruitmentId(recruitmentId);
+	}
+}

--- a/src/main/java/com/yoyomo/domain/application/domain/service/EvaluationMemoDeleteService.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/service/EvaluationMemoDeleteService.java
@@ -1,0 +1,21 @@
+package com.yoyomo.domain.application.domain.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.yoyomo.domain.application.domain.repository.EvaluationMemoRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EvaluationMemoDeleteService {
+	private final EvaluationMemoRepository evaluationMemoRepository;
+
+	public void deleteByRecruitmentId(UUID recruitmentId) {
+		evaluationMemoRepository.deleteByRecruitmentId(recruitmentId);
+	}
+}

--- a/src/main/java/com/yoyomo/domain/recruitment/application/usecase/RecruitmentManageUseCase.java
+++ b/src/main/java/com/yoyomo/domain/recruitment/application/usecase/RecruitmentManageUseCase.java
@@ -12,7 +12,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.yoyomo.domain.application.domain.repository.EvaluationMemoRepository;
 import com.yoyomo.domain.application.domain.service.ApplicationDeleteService;
+import com.yoyomo.domain.application.domain.service.EvaluationDeleteService;
+import com.yoyomo.domain.application.domain.service.EvaluationMemoDeleteService;
 import com.yoyomo.domain.club.domain.entity.Club;
 import com.yoyomo.domain.club.domain.service.ClubGetService;
 import com.yoyomo.domain.club.domain.service.ClubManagerAuthService;
@@ -58,6 +61,9 @@ public class RecruitmentManageUseCase {
 	private final ApplicationDeleteService applicationDeleteService;
 	private final ProcessSaveService processSaveService;
 	private final ProcessGetService processGetService;
+	private final EvaluationDeleteService evaluationDeleteService;
+	private final EvaluationMemoRepository evaluationMemoRepository;
+	private final EvaluationMemoDeleteService evaluationMemoDeleteService;
 
 	@Transactional
 	public RecruitmentCreateResponse save(Save dto, User manager) {
@@ -114,8 +120,13 @@ public class RecruitmentManageUseCase {
 	public void cancel(String recruitmentId, User user) {
 		Recruitment recruitment = checkAuthorityByRecruitment(recruitmentId, user);
 
+		evaluationMemoDeleteService.deleteByRecruitmentId(recruitment.getId());
+		evaluationDeleteService.deleteEvaluationByRecruitmentId(recruitment.getId());
+
 		applicationDeleteService.deleteByRecruitmentId(recruitment);
+
 		processDeleteService.deleteAllByRecruitment(recruitment);
+
 		recruitmentDeleteService.delete(recruitment);
 	}
 

--- a/src/test/java/com/yoyomo/domain/fixture/TestFixture.java
+++ b/src/test/java/com/yoyomo/domain/fixture/TestFixture.java
@@ -1,8 +1,16 @@
 package com.yoyomo.domain.fixture;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.UUID;
+
 import com.yoyomo.domain.application.domain.entity.Application;
+import com.yoyomo.domain.application.domain.entity.Evaluation;
+import com.yoyomo.domain.application.domain.entity.EvaluationMemo;
 import com.yoyomo.domain.application.domain.entity.InterviewRecord;
 import com.yoyomo.domain.application.domain.entity.ProcessResult;
+import com.yoyomo.domain.application.domain.entity.enums.Rating;
 import com.yoyomo.domain.application.domain.entity.enums.Status;
 import com.yoyomo.domain.club.domain.entity.Club;
 import com.yoyomo.domain.club.domain.entity.ClubManager;
@@ -14,120 +22,140 @@ import com.yoyomo.domain.recruitment.domain.entity.Recruitment;
 import com.yoyomo.domain.recruitment.domain.entity.enums.Type;
 import com.yoyomo.domain.user.domain.entity.User;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.UUID;
-
 public class TestFixture {
 
-    public static User user() {
-        return User.builder()
-                .name("아연")
-                .email("naayen@crayon.land")
-                .tel("01012345678")
-                .build();
-    }
+	public static User user() {
+		return User.builder()
+			.name("아연")
+			.email("naayen@crayon.land")
+			.tel("01012345678")
+			.build();
+	}
 
-    public static Club club() {
-        return Club.builder()
-                .name("끄래용~")
-                .subDomain("yoyomo")
-                .build();
-    }
+	public static Club club() {
+		return Club.builder()
+			.name("끄래용~")
+			.subDomain("yoyomo")
+			.build();
+	}
 
-    public static ClubManager clubManager(Club club, User user) {
-        return ClubManager.asManager(club, user);
-    }
+	public static ClubManager clubManager(Club club, User user) {
+		return ClubManager.asManager(club, user);
+	}
 
-    public static InterviewRecord interviewRecord(User manager) {
-        return InterviewRecord.builder()
-                .applicationId(UUID.randomUUID())
-                .manager(manager)
-                .content("면접 태도가 좋네요")
-                .build();
-    }
+	public static InterviewRecord interviewRecord(User manager) {
+		return InterviewRecord.builder()
+			.applicationId(UUID.randomUUID())
+			.manager(manager)
+			.content("면접 태도가 좋네요")
+			.build();
+	}
 
-    public static Recruitment recruitment(Club club) {
-        return Recruitment.builder()
-                .title("모집")
-                .isActive(false)
-                .startAt(LocalDateTime.now().minusHours(1))
-                .endAt(LocalDateTime.now().plusDays(1))
-                .currentProcess(Type.FORM)
-                .club(club)
-                .processes(new ArrayList<>())
-                .build();
-    }
+	public static Recruitment recruitment(Club club) {
+		return Recruitment.builder()
+			.title("모집")
+			.isActive(false)
+			.startAt(LocalDateTime.now().minusHours(1))
+			.endAt(LocalDateTime.now().plusDays(1))
+			.currentProcess(Type.FORM)
+			.club(club)
+			.processes(new ArrayList<>())
+			.build();
+	}
 
-    public static Recruitment recruitment(Club club, Process... processes) {
-        return Recruitment.builder()
-                .title("모집")
-                .isActive(false)
-                .startAt(LocalDateTime.now().minusHours(1))
-                .endAt(LocalDateTime.now().plusDays(1))
-                .currentProcess(Type.FORM)
-                .club(club)
-                .processes(Arrays.stream(processes).toList())
-                .build();
-    }
+	public static Recruitment recruitment(Club club, Process... processes) {
+		return Recruitment.builder()
+			.title("모집")
+			.isActive(false)
+			.startAt(LocalDateTime.now().minusHours(1))
+			.endAt(LocalDateTime.now().plusDays(1))
+			.currentProcess(Type.FORM)
+			.club(club)
+			.processes(Arrays.stream(processes).toList())
+			.build();
+	}
 
-    public static Application application(User user) {
-        return Application.builder()
-                .user(user)
-                .recruitmentId(UUID.randomUUID())
-                .build();
-    }
+	public static Application application(User user) {
+		return Application.builder()
+			.user(user)
+			.recruitmentId(UUID.randomUUID())
+			.build();
+	}
 
-    public static Application application(User user, Process process) {
-        return Application.builder()
-                .user(user)
-                .process(process)
-                .recruitmentId(UUID.randomUUID())
-                .build();
-    }
+	public static Application application(User user, Process process) {
+		return Application.builder()
+			.user(user)
+			.process(process)
+			.recruitmentId(UUID.randomUUID())
+			.build();
+	}
 
-    public static Process process() {
-        return Process.builder()
-                .build();
-    }
+	public static Application application(User user, Process process, UUID recruitmentId) {
+		return Application.builder()
+			.user(user)
+			.process(process)
+			.recruitmentId(recruitmentId)
+			.build();
+	}
 
-    public static Process process(int stage) {
-        return Process.builder()
-                .stage(stage)
-                .build();
-    }
+	public static Process process() {
+		return Process.builder()
+			.build();
+	}
 
-    public static ProcessResult processResult(UUID applicationId, long processId, Status status) {
-        return ProcessResult.builder()
-                .applicationId(applicationId)
-                .processId(processId)
-                .status(status)
-                .build();
-    }
+	public static Process process(int stage) {
+		return Process.builder()
+			.stage(stage)
+			.build();
+	}
 
-    public static Date dateItem() {
-        return Date.builder()
-                .title("날짜를 선택해주세요")
-                .type(com.yoyomo.domain.item.domain.entity.type.Type.CALENDAR)
-                .order(0)
-                .required(false)
-                .build();
-    }
+	public static ProcessResult processResult(UUID applicationId, long processId, Status status) {
+		return ProcessResult.builder()
+			.applicationId(applicationId)
+			.processId(processId)
+			.status(status)
+			.build();
+	}
 
-    public static Answer shortFormItem() {
-        return Answer.builder()
-                .title("단답형으로 입력해주세요")
-                .type(com.yoyomo.domain.item.domain.entity.type.Type.SHORT_FORM)
-                .order(1)
-                .required(false)
-                .build();
-    }
+	public static Evaluation evaluation(Application application, User user, Rating rating) {
+		return Evaluation.builder()
+			.application(application)
+			.manager(user)
+			.rating(rating)
+			.build();
+	}
 
-    public static Form form(String clubId) {
-        return Form.builder()
-                .clubId(clubId)
-                .title("폼 제목입니다")
-                .build();
-    }
+	public static EvaluationMemo evaluationMemo(Application application, User user, long processId) {
+		return EvaluationMemo.builder()
+			.memo("낫뱃")
+			.application(application)
+			.manager(user)
+			.processId(processId)
+			.build();
+	}
+
+	public static Date dateItem() {
+		return Date.builder()
+			.title("날짜를 선택해주세요")
+			.type(com.yoyomo.domain.item.domain.entity.type.Type.CALENDAR)
+			.order(0)
+			.required(false)
+			.build();
+	}
+
+	public static Answer shortFormItem() {
+		return Answer.builder()
+			.title("단답형으로 입력해주세요")
+			.type(com.yoyomo.domain.item.domain.entity.type.Type.SHORT_FORM)
+			.order(1)
+			.required(false)
+			.build();
+	}
+
+	public static Form form(String clubId) {
+		return Form.builder()
+			.clubId(clubId)
+			.title("폼 제목입니다")
+			.build();
+	}
 }

--- a/src/test/java/com/yoyomo/domain/recruitment/application/usecase/RecruitmentManageUseCaseTest.java
+++ b/src/test/java/com/yoyomo/domain/recruitment/application/usecase/RecruitmentManageUseCaseTest.java
@@ -1,0 +1,96 @@
+package com.yoyomo.domain.recruitment.application.usecase;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.yoyomo.domain.ApplicationTest;
+import com.yoyomo.domain.application.domain.entity.Application;
+import com.yoyomo.domain.application.domain.entity.enums.Rating;
+import com.yoyomo.domain.application.domain.repository.ApplicationRepository;
+import com.yoyomo.domain.application.domain.repository.EvaluationMemoRepository;
+import com.yoyomo.domain.application.domain.repository.EvaluationRepository;
+import com.yoyomo.domain.application.domain.repository.mongo.AnswerRepository;
+import com.yoyomo.domain.club.domain.entity.Club;
+import com.yoyomo.domain.club.domain.repository.ClubMangerRepository;
+import com.yoyomo.domain.club.domain.repository.ClubRepository;
+import com.yoyomo.domain.fixture.TestFixture;
+import com.yoyomo.domain.recruitment.domain.entity.Process;
+import com.yoyomo.domain.recruitment.domain.entity.Recruitment;
+import com.yoyomo.domain.recruitment.domain.repository.ProcessRepository;
+import com.yoyomo.domain.recruitment.domain.repository.RecruitmentRepository;
+import com.yoyomo.domain.user.domain.entity.User;
+import com.yoyomo.domain.user.domain.repository.UserRepository;
+
+class RecruitmentManageUseCaseTest extends ApplicationTest {
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	ClubMangerRepository clubMangerRepository;
+
+	@Autowired
+	ClubRepository clubRepository;
+
+	@Autowired
+	RecruitmentRepository recruitmentRepository;
+
+	@Autowired
+	ProcessRepository processRepository;
+
+	@Autowired
+	ApplicationRepository applicationRepository;
+
+	@Autowired
+	AnswerRepository answerRepository;
+
+	@Autowired
+	RecruitmentManageUseCase recruitmentManageUseCase;
+
+	@Autowired
+	EvaluationRepository evaluationRepository;
+
+	@Autowired
+	EvaluationMemoRepository evaluationMemoRepository;
+
+	@DisplayName("동아리 관리자는 모집을 삭제할 수 있다.")
+	@Test
+	void deleteRecruitment() {
+		// given
+		User manager = userRepository.save(TestFixture.user());
+		User applicant = userRepository.save(TestFixture.user());
+		Club club = clubRepository.save(TestFixture.club());
+		clubMangerRepository.save(TestFixture.clubManager(club, manager));
+
+		Process process = processRepository.save(TestFixture.process(1));
+		Recruitment recruitment = recruitmentRepository.save(TestFixture.recruitment(club, process));
+		process.addRecruitment(recruitment);
+		processRepository.save(process);
+
+		Application application = applicationRepository.save(
+			TestFixture.application(applicant, process, recruitment.getId()));
+		Application application2 = applicationRepository.save(
+			TestFixture.application(applicant, process, recruitment.getId()));
+
+		evaluationRepository.save(TestFixture.evaluation(application, applicant, Rating.HIGH));
+		evaluationRepository.save(TestFixture.evaluation(application2, applicant, Rating.HIGH));
+
+		evaluationMemoRepository.save(
+			TestFixture.evaluationMemo(application, manager, process.getId()));
+		evaluationMemoRepository.save(
+			TestFixture.evaluationMemo(application2, manager, process.getId()));
+
+		// when
+		recruitmentManageUseCase.cancel(recruitment.getId().toString(), manager);
+
+		// then
+		assertThat(recruitmentRepository.findById(recruitment.getId())).isEmpty();
+		List<Application> applications = applicationRepository.findAll();
+		assertThat(applications).isEmpty();
+	}
+}


### PR DESCRIPTION
## 🚀 PR 요약
모집 삭제할 때 평가, 평가 메모가 있으면 제약조건으로 삭제가 되지 않아 수정했습니다.

## ✨ PR 상세 내용
우선 직접적인 연관관계를 가진
Evaluation
EvaluationMemo 만 삭제하도록 구현했습니다 ..
다 지울까요..? 

## 🚨 주의 사항
위에 쓴것 처럼 일단 평가랑 평가메모만 지웠는데 다 지우는게 나을까요? 의견좀 ㅎㅎ..

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
