### PR TITLE
CRA-168 메일 한도 제한 오류 및 수집 메트릭 설정 변경

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,11 +80,11 @@ jobs:
         run: ./gradlew build -x test
 
       # 도커 이미지 생성 후 이미지 push
-      - name: Docker build & push to dev
+      - name: Docker build & push to remote
         run: |
           docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
           docker buildx create --use
-          docker buildx build --platform linux/arm64 -f Dockerfile-dev -t ${{ secrets.DOCKERHUB_USERNAME }}/crayon --push .
+          docker buildx build --platform linux/arm64 -f Dockerfile -t ${{ secrets.DOCKERHUB_USERNAME }}/crayon --push .
 
       # EC2 ssh 연결 후 이미지 pull
       - name: Deploy to server

--- a/src/main/java/com/yoyomo/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/yoyomo/global/config/redis/RedisConfig.java
@@ -75,7 +75,6 @@ public class RedisConfig {
         template.setConnectionFactory(rateLimitConnectionFactory());
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new GenericToStringSerializer<>(Long.class));
-        template.setEnableTransactionSupport(true);
         template.afterPropertiesSet();
         return template;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,7 +64,12 @@ management:
     web:
       exposure:
         include: ${CRAYON_MONITOR_ENDPOINT}
-
+  metrics:
+    distribution:
+      percentiles:
+        http.server.requests: [ 0.95, 0.99 ]
+      percentiles-histogram:
+        http.server.requests: true
   endpoint:
     metrics:
       enabled: true


### PR DESCRIPTION
## 🚀 PR 요약
- 메일 한도 제한 오류 수정
- 응답시간 메트릭 수집
- 운영환경 profile `prod` 로 수정

## ✨ PR 상세 내용
- 메일 한도 제한에 사용되는 Redis Template 의 트랜잭션 설정을 off 했습니다
  - Lua Script를 사용하는 경우 트랜잭션 큐에 들어가고 실행되지 않기 때문에 null 이 반환된다고 합니다
- 응답시간 관련 메트릭을 추가했습니다 

## 🚨 주의 사항
주의할 부분이 무엇인가요? - 지우고 작성

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?


closed #407 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 레디스 기반 요청 제한 기능에서 트랜잭션 지원이 비활성화되었습니다.

- **문서화**
  - HTTP 서버 요청에 대한 95, 99 퍼센타일 및 퍼센타일 히스토그램을 포함하도록 메트릭 분포 설정이 추가되었습니다.

- **기타**
  - 도커 이미지 빌드 및 푸시 작업명이 변경되고, 도커파일이 `Dockerfile-dev`에서 `Dockerfile`로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->