### PR TITLE
예외 메시지 수정

### DIFF
--- a/src/main/java/com/yoyomo/domain/application/application/dto/request/EvaluationMemoRequest.java
+++ b/src/main/java/com/yoyomo/domain/application/application/dto/request/EvaluationMemoRequest.java
@@ -3,11 +3,13 @@ package com.yoyomo.domain.application.application.dto.request;
 import com.yoyomo.domain.application.domain.entity.Application;
 import com.yoyomo.domain.application.domain.entity.EvaluationMemo;
 import com.yoyomo.domain.user.domain.entity.User;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record EvaluationMemoRequest(
 
-        @NotNull
+        @NotBlank
+        @Size(max = 255, message = "250자 이하로 작성해주세요")
         String memo
 ) {
     public EvaluationMemo toEvaluationMemo(User manager, Application application) {

--- a/src/main/java/com/yoyomo/global/config/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/yoyomo/global/config/exception/GlobalExceptionHandler.java
@@ -90,7 +90,7 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
                 .status(status)
-                .body(ResponseDto.of(status, ex.getMessage()));
+                .body(ResponseDto.of(status, "서버 오류가 발생했습니다"));
     }
 
     // @Valid에서 발생하는 예외 처리


### PR DESCRIPTION
## 🚀 PR 요약
예외 메시지를 수정했습니다

## ✨ PR 상세 내용
서버 오류의 경우, 예외 메시지 그대로가 아닌 `서버 오류가 발생했습니다`를 전달합니다

## 🚨 주의 사항
주의할 부분이 무엇인가요? - 지우고 작성

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 메모 입력란에 공백만 입력하거나 255자를 초과하여 입력할 수 없도록 검증이 강화되었습니다.
  - 서버 오류 발생 시 반환되는 메시지가 "서버 오류가 발생했습니다"로 고정되어 안내가 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->