### PR TITLE
CRA-171 같은 지원자가 동시에 두번 지원할 경우 지원되는 현상 수정

### DIFF
--- a/src/main/java/com/yoyomo/domain/application/domain/entity/Application.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/entity/Application.java
@@ -1,11 +1,15 @@
 package com.yoyomo.domain.application.domain.entity;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 
 import com.yoyomo.domain.application.exception.AccessDeniedException;
 import com.yoyomo.domain.recruitment.domain.entity.Process;
 import com.yoyomo.domain.recruitment.domain.entity.enums.Type;
 import com.yoyomo.domain.user.domain.entity.User;
 import com.yoyomo.global.common.entity.BaseEntity;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -15,81 +19,82 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
-
-
 @Getter
 @Builder
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(uniqueConstraints = {
+	@UniqueConstraint(
+		columnNames = {"recruitment_id", "user_id"}
+	)})
 public class Application extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "application_id")
-    private UUID id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "application_id")
+	private UUID id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
 
-    private String userName;
+	private String userName;
 
-    private String email;
+	private String email;
 
-    @Column(length = 13)
-    private String tel;
+	@Column(length = 13)
+	private String tel;
 
-    @Column(nullable = false, name = "recruitment_id")
-    private UUID recruitmentId;
+	@Column(nullable = false, name = "recruitment_id")
+	private UUID recruitmentId;
 
-    @ManyToOne
-    @JoinColumn(name = "process_id")
-    private Process process;
+	@ManyToOne
+	@JoinColumn(name = "process_id")
+	private Process process;
 
-    @Embedded
-    private Interview interview;
+	@Embedded
+	private Interview interview;
 
-    private LocalDateTime deletedAt;
+	private LocalDateTime deletedAt;
 
-    public UUID generateId() {
-        this.id = UUID.randomUUID();
-        return id;
-    }
+	public UUID generateId() {
+		this.id = UUID.randomUUID();
+		return id;
+	}
 
-    public void update(Process process) {
-        this.process = process;
-    }
+	public void update(Process process) {
+		this.process = process;
+	}
 
-    public void addInterview(Interview interview) {
-        this.interview = interview;
-    }
+	public void addInterview(Interview interview) {
+		this.interview = interview;
+	}
 
-    public void delete() {
-        this.deletedAt = LocalDateTime.now();
-    }
+	public void delete() {
+		this.deletedAt = LocalDateTime.now();
+	}
 
-    public void checkAuthorization(User user) {
-        if (!this.user.equals(user)) {
-            throw new AccessDeniedException();
-        }
-    }
+	public void checkAuthorization(User user) {
+		if (!this.user.equals(user)) {
+			throw new AccessDeniedException();
+		}
+	}
 
-    public boolean isBeforeInterview(List<Type> types) {
+	public boolean isBeforeInterview(List<Type> types) {
 
-        if (!types.contains(Type.INTERVIEW)) {
-            return false;
-        }
+		if (!types.contains(Type.INTERVIEW)) {
+			return false;
+		}
 
-        return types.indexOf(Type.INTERVIEW) > this.getProcess().getStage();
-    }
+		return types.indexOf(Type.INTERVIEW) > this.getProcess().getStage();
+	}
 }

--- a/src/test/java/com/yoyomo/domain/application/domain/service/ApplicationSaveServiceTest.java
+++ b/src/test/java/com/yoyomo/domain/application/domain/service/ApplicationSaveServiceTest.java
@@ -1,82 +1,137 @@
 package com.yoyomo.domain.application.domain.service;
 
-import com.yoyomo.domain.ApplicationTest;
-import com.yoyomo.domain.club.domain.entity.Club;
-import com.yoyomo.domain.club.domain.repository.ClubRepository;
-import com.yoyomo.domain.recruitment.domain.repository.RecruitmentRepository;
-import com.yoyomo.domain.user.domain.entity.User;
-import com.yoyomo.domain.user.domain.repository.UserRepository;
-import jakarta.persistence.EntityManager;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import static com.yoyomo.domain.fixture.TestFixture.*;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.yoyomo.domain.fixture.TestFixture.application;
-import static com.yoyomo.domain.fixture.TestFixture.club;
-import static com.yoyomo.domain.fixture.TestFixture.recruitment;
-import static com.yoyomo.domain.fixture.TestFixture.user;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.yoyomo.domain.ApplicationTest;
+import com.yoyomo.domain.application.domain.entity.Application;
+import com.yoyomo.domain.application.domain.repository.ApplicationRepository;
+import com.yoyomo.domain.club.domain.entity.Club;
+import com.yoyomo.domain.club.domain.repository.ClubRepository;
+import com.yoyomo.domain.recruitment.domain.entity.Process;
+import com.yoyomo.domain.recruitment.domain.repository.ProcessRepository;
+import com.yoyomo.domain.recruitment.domain.repository.RecruitmentRepository;
+import com.yoyomo.domain.user.domain.entity.User;
+import com.yoyomo.domain.user.domain.repository.UserRepository;
+
+import jakarta.persistence.EntityManager;
 
 class ApplicationSaveServiceTest extends ApplicationTest {
 
-    @Autowired
-    private ClubRepository clubRepository;
+	@Autowired
+	private ClubRepository clubRepository;
 
-    @Autowired
-    private RecruitmentRepository recruitmentRepository;
+	@Autowired
+	private RecruitmentRepository recruitmentRepository;
 
-    @Autowired
-    private UserRepository userRepository;
+	@Autowired
+	private UserRepository userRepository;
 
-    @Autowired
-    private ApplicationSaveService applicationSaveService;
+	@Autowired
+	private ApplicationSaveService applicationSaveService;
 
-    @Autowired
-    private EntityManager entityManager;
+	@Autowired
+	private ProcessRepository processRepository;
 
-    @DisplayName("동시에 지원하는 경우 지원자 수가 정상 반영된다.")
-    @Test
-    void save() throws InterruptedException {
-        // given
-        Club club = clubRepository.save(club());
-        UUID recruitmentId = recruitmentRepository.save(recruitment(club)).getId();
+	@Autowired
+	private EntityManager entityManager;
 
-        List<User> users = new ArrayList<>();
-        for (int i = 0; i < 100; i++) {
-            users.add(userRepository.save(user()));
-        }
+	@Autowired
+	private ApplicationRepository applicationRepository;
 
-        // when
-        int threadCount = 100;
-        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-        CountDownLatch latch = new CountDownLatch(threadCount);
+	@DisplayName("동시에 지원하는 경우 지원자 수가 정상 반영된다.")
+	@Test
+	void save() throws InterruptedException {
+		// given
+		Club club = clubRepository.save(club());
+		UUID recruitmentId = recruitmentRepository.save(recruitment(club)).getId();
 
-        for (int i = 0; i < threadCount; i++) {
-            int finalI = i;
-            executorService.submit(() -> {
-                try {
-                    applicationSaveService.save(recruitmentId, application(users.get(finalI)));
-                } finally {
-                    latch.countDown();
-                }
-            });
-        }
-        latch.await();
-        executorService.shutdown();
+		List<User> users = new ArrayList<>();
+		for (int i = 0; i < 100; i++) {
+			users.add(userRepository.save(user()));
+		}
 
-        // then
-        entityManager.clear();
-        assertThat(recruitmentRepository.findById(recruitmentId))
-                .isPresent()
-                .hasValueSatisfying(result ->
-                        assertThat(result.getTotalApplicantsCount()).isEqualTo(threadCount)
-                );
-    }
+		// when
+		int threadCount = 100;
+		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch latch = new CountDownLatch(threadCount);
+
+		for (int i = 0; i < threadCount; i++) {
+			int finalI = i;
+			executorService.submit(() -> {
+				try {
+					applicationSaveService.save(recruitmentId, application(users.get(finalI)));
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+		latch.await();
+		executorService.shutdown();
+
+		// then
+		entityManager.clear();
+		assertThat(recruitmentRepository.findById(recruitmentId))
+			.isPresent()
+			.hasValueSatisfying(result ->
+				assertThat(result.getTotalApplicantsCount()).isEqualTo(threadCount)
+			);
+	}
+
+	@DisplayName("동시에 여러 개의 지원서가 들어올 경우 하나의 지원서만 저장된다.")
+	@Test
+	void test() throws InterruptedException {
+		//given
+		Club club = clubRepository.save(club());
+		UUID recruitmentId = recruitmentRepository.save(recruitment(club)).getId();
+		User user = userRepository.save(user());
+		Process process = processRepository.save(process());
+
+		//when
+		int threadCount = 3;
+		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch latch = new CountDownLatch(threadCount);
+
+		AtomicInteger successCount = new AtomicInteger(0);
+		AtomicInteger exceptionCount = new AtomicInteger(0);
+		List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
+
+		for (int i = 0; i < threadCount; i++) {
+			executorService.submit(() -> {
+				try {
+					Application application = application(user, process, recruitmentId);
+
+					applicationRepository.save(application);
+					successCount.incrementAndGet();
+
+				} catch (Exception e) {
+					exceptions.add(e);
+					exceptionCount.incrementAndGet();
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+		executorService.shutdown();
+
+		// then
+		List<Application> savedApplications = applicationRepository.findAllByUserAndDeletedAtIsNull(user);
+		assertThat(savedApplications).hasSize(1);
+	}
+
 }

--- a/src/test/java/com/yoyomo/domain/application/domain/service/ApplicationSaveServiceTest.java
+++ b/src/test/java/com/yoyomo/domain/application/domain/service/ApplicationSaveServiceTest.java
@@ -93,7 +93,7 @@ class ApplicationSaveServiceTest extends ApplicationTest {
 
 	@DisplayName("동시에 여러 개의 지원서가 들어올 경우 하나의 지원서만 저장된다.")
 	@Test
-	void test() throws InterruptedException {
+	void saveAtomic() throws InterruptedException {
 		//given
 		Club club = clubRepository.save(club());
 		UUID recruitmentId = recruitmentRepository.save(recruitment(club)).getId();

--- a/src/test/java/com/yoyomo/domain/recruitment/application/usecase/RecruitmentManageUseCaseTest.java
+++ b/src/test/java/com/yoyomo/domain/recruitment/application/usecase/RecruitmentManageUseCaseTest.java
@@ -60,6 +60,7 @@ class RecruitmentManageUseCaseTest extends ApplicationTest {
 		// given
 		User manager = userRepository.save(TestFixture.user());
 		User applicant = userRepository.save(TestFixture.user());
+		User applicant2 = userRepository.save(TestFixture.user());
 		Club club = clubRepository.save(TestFixture.club());
 		clubMangerRepository.save(TestFixture.clubManager(club, manager));
 
@@ -71,7 +72,7 @@ class RecruitmentManageUseCaseTest extends ApplicationTest {
 		Application application = applicationRepository.save(
 			TestFixture.application(applicant, process, recruitment.getId()));
 		Application application2 = applicationRepository.save(
-			TestFixture.application(applicant, process, recruitment.getId()));
+			TestFixture.application(applicant2, process, recruitment.getId()));
 
 		evaluationRepository.save(TestFixture.evaluation(application, applicant, Rating.HIGH));
 		evaluationRepository.save(TestFixture.evaluation(application2, applicant, Rating.HIGH));


### PR DESCRIPTION
## 🚀 PR 요약
지원서 동시성 해결 

## ✨ PR 상세 내용
recruitment_id와 user_id를 unique key로 걸었습니다.

## 🚨 주의 사항
없습니당

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] #0 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 지원서 엔티티에 대해 동일한 모집과 사용자 조합에 대한 중복 지원이 불가능하도록 데이터베이스 제약 조건이 추가되었습니다.

* **테스트**
  * 여러 사용자가 동시에 지원할 때 중복 지원이 저장되지 않는지 검증하는 테스트가 추가되었습니다.
  * 동일 모집에 여러 지원자가 지원하는 시나리오를 반영하도록 테스트가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->