### PR TITLE
CRA-187 지원일 오래된순 정렬 추가

### DIFF
--- a/src/main/java/com/yoyomo/domain/application/domain/repository/ApplicationQueryDslRepositoryImpl.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/repository/ApplicationQueryDslRepositoryImpl.java
@@ -33,7 +33,8 @@ public class ApplicationQueryDslRepositoryImpl implements ApplicationQueryDslRep
 
 	private static final Map<SortType, OrderSpecifier<?>> ORDER_SPECIFIER_MAP = Map.of(
 		SortType.NAME, new OrderSpecifier<>(Order.ASC, application.userName),
-		SortType.APPLIED, new OrderSpecifier<>(Order.DESC, application.createdAt)
+		SortType.OLDEST, new OrderSpecifier<>(Order.ASC, application.createdAt),
+		SortType.LATEST, new OrderSpecifier<>(Order.DESC, application.createdAt)
 	);
 
 	private final JPAQueryFactory queryFactory;

--- a/src/main/java/com/yoyomo/domain/application/domain/vo/condition/SortType.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/vo/condition/SortType.java
@@ -11,7 +11,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SortType {
 	NAME("name"),
-	APPLIED("applied"),
 	LATEST("latest"),
 	OLDEST("oldest");
 

--- a/src/main/java/com/yoyomo/domain/application/domain/vo/condition/SortType.java
+++ b/src/main/java/com/yoyomo/domain/application/domain/vo/condition/SortType.java
@@ -11,7 +11,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SortType {
 	NAME("name"),
-	APPLIED("applied");
+	APPLIED("applied"),
+	LATEST("latest"),
+	OLDEST("oldest");
+
 	private final String value;
 
 	public static SortType from(String type) {

--- a/src/main/java/com/yoyomo/domain/application/presentation/ApplicationController.java
+++ b/src/main/java/com/yoyomo/domain/application/presentation/ApplicationController.java
@@ -145,7 +145,7 @@ public class ApplicationController {
 		@RequestParam Integer stage,
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "5") int size,
-		@RequestParam(defaultValue = "applied") String sort,
+		@RequestParam(defaultValue = "latest") String sort,
 		@RequestParam(defaultValue = "all") String evaluationFilter,
 		@RequestParam(defaultValue = "all") String resultFilter
 	) {

--- a/src/test/java/com/yoyomo/domain/application/domain/repository/ApplicationRepositoryTest.java
+++ b/src/test/java/com/yoyomo/domain/application/domain/repository/ApplicationRepositoryTest.java
@@ -121,7 +121,7 @@ class ApplicationRepositoryTest extends RepositoryTest {
 		@Test
 		void findAllWithStatusByProcess_filterPass() {
 			ApplicationCondition condition = new ApplicationCondition(
-				SortType.APPLIED, EvaluationFilter.ALL, ResultFilter.PASS
+				SortType.LATEST, EvaluationFilter.ALL, ResultFilter.PASS
 			);
 			PageRequest pageRequest = PageRequest.of(0, 5);
 
@@ -140,7 +140,7 @@ class ApplicationRepositoryTest extends RepositoryTest {
 		@Test
 		void findAllWithStatusByProcess_filterFail() {
 			ApplicationCondition condition = new ApplicationCondition(
-				SortType.APPLIED, EvaluationFilter.ALL, ResultFilter.FAIL
+				SortType.LATEST, EvaluationFilter.ALL, ResultFilter.FAIL
 			);
 			PageRequest pageRequest = PageRequest.of(0, 5);
 
@@ -159,7 +159,7 @@ class ApplicationRepositoryTest extends RepositoryTest {
 		@Test
 		void findAllWithStatusByProcess_filterPending() {
 			ApplicationCondition condition = new ApplicationCondition(
-				SortType.APPLIED, EvaluationFilter.ALL, ResultFilter.PENDING
+				SortType.LATEST, EvaluationFilter.ALL, ResultFilter.PENDING
 			);
 			PageRequest pageRequest = PageRequest.of(0, 5);
 
@@ -180,7 +180,7 @@ class ApplicationRepositoryTest extends RepositoryTest {
 		@Test
 		void findAllWithStatusByProcess_filterWithoutResult() {
 			ApplicationCondition condition = new ApplicationCondition(
-				SortType.APPLIED, EvaluationFilter.ALL, ResultFilter.NONE
+				SortType.LATEST, EvaluationFilter.ALL, ResultFilter.NONE
 			);
 			PageRequest pageRequest = PageRequest.of(0, 5);
 
@@ -197,7 +197,7 @@ class ApplicationRepositoryTest extends RepositoryTest {
 	}
 
 	@Nested
-	class EvaluationTest {
+	class EvaluationFilterTest {
 
 		private int hasEvalautionCount = 2;
 		private int hasNotEvalautionCount = 3;
@@ -221,7 +221,7 @@ class ApplicationRepositoryTest extends RepositoryTest {
 		@Test
 		void findAllWithStatusByProcess_hasEvaluation() {
 			ApplicationCondition condition = new ApplicationCondition(
-				SortType.APPLIED, EvaluationFilter.YES, ResultFilter.ALL
+				SortType.LATEST, EvaluationFilter.YES, ResultFilter.ALL
 			);
 			PageRequest pageRequest = PageRequest.of(0, 5);
 
@@ -241,7 +241,7 @@ class ApplicationRepositoryTest extends RepositoryTest {
 		@Test
 		void findAllWithStatusByProcess_hasNotEvaluation() {
 			ApplicationCondition condition = new ApplicationCondition(
-				SortType.APPLIED, EvaluationFilter.NO, ResultFilter.ALL
+				SortType.LATEST, EvaluationFilter.NO, ResultFilter.ALL
 			);
 			PageRequest pageRequest = PageRequest.of(0, 5);
 
@@ -265,7 +265,7 @@ class ApplicationRepositoryTest extends RepositoryTest {
 		@Test
 		void findAllWithStatusByProcess_OrderByCreatedAtDesc() {
 			ApplicationCondition condition = new ApplicationCondition(
-				SortType.APPLIED, EvaluationFilter.ALL, ResultFilter.ALL
+				SortType.LATEST, EvaluationFilter.ALL, ResultFilter.ALL
 			);
 			PageRequest pageRequest = PageRequest.of(0, 5);
 
@@ -283,6 +283,32 @@ class ApplicationRepositoryTest extends RepositoryTest {
 					applications.get(2).getId(),
 					applications.get(1).getId(),
 					applications.get(0).getId()
+				)
+			);
+		}
+
+		@DisplayName("생성일 기준 내림차순 정렬한다")
+		@Test
+		void findAllWithStatusByProcess_OrderByCreatedAtAsc() {
+			ApplicationCondition condition = new ApplicationCondition(
+				SortType.OLDEST, EvaluationFilter.ALL, ResultFilter.ALL
+			);
+			PageRequest pageRequest = PageRequest.of(0, 5);
+
+			List<UUID> applicationIds = applicationRepository.findAllWithStatusByProcess(
+					process, condition, pageRequest)
+				.getContent()
+				.stream()
+				.map(applicationWithStatus -> applicationWithStatus.application().getId())
+				.toList();
+
+			assertThat(applicationIds).containsExactlyElementsOf(
+				List.of(
+					applications.get(0).getId(),
+					applications.get(1).getId(),
+					applications.get(2).getId(),
+					applications.get(3).getId(),
+					applications.get(4).getId()
 				)
 			);
 		}
@@ -321,7 +347,7 @@ class ApplicationRepositoryTest extends RepositoryTest {
 		@Test
 		void findAllWithStatusByProcess_withPage() {
 			ApplicationCondition condition = new ApplicationCondition(
-				SortType.APPLIED, EvaluationFilter.ALL, ResultFilter.ALL
+				SortType.LATEST, EvaluationFilter.ALL, ResultFilter.ALL
 			);
 
 			List<UUID> result1 = applicationRepository.findAllWithStatusByProcess(


### PR DESCRIPTION
## 🚀 PR 요약

지원일 오래된 순 정렬 기능을 추가합니다

## ✨ PR 상세 내용

- 기존 정렬 키워드를 변경했습니다. (기본값)
  - applied : 지원일 최신순 -> latest
- 오래된 순 정렬 키워드를 추가했습니다 
  - oldest : 지원일 오래된순

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. CRA-00 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?


closed #432 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 목록 정렬 옵션에 ‘최신순’과 ‘오래된순’을 추가하여 생성일 기준 정렬을 지원합니다.
  - 기본 정렬이 ‘applied(제출일)’에서 ‘latest(최신순)’으로 변경되었습니다. 기존 ‘applied’ 옵션은 더 이상 제공되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->